### PR TITLE
fix(sync): preserve user core overrides across skills sync

### DIFF
--- a/src/commands/skills/sync.rs
+++ b/src/commands/skills/sync.rs
@@ -812,7 +812,7 @@ mod tests {
 
         // User's existing library.json: test-skill is core: true
         let library_dir = paths.data_dir();
-        std::fs::create_dir_all(&library_dir).unwrap();
+        std::fs::create_dir_all(library_dir).unwrap();
         let user_lib = r#"{"version":1,"specs":[{"id":"test-skill","type":"skill","name":"Test Skill","description":"A test","core":true,"tags":[],"triggers":{}}]}"#;
         std::fs::write(paths.library_json(), user_lib).unwrap();
 


### PR DESCRIPTION
## Problem

When a user sets a skill as `core` via `akm skills status` or `akm skills list`, the preference is lost after the next `akm skills sync` or `akm sync`. This is a regression from the Bash version which preserved user `core` preferences.

**Root cause:** `copy_registry_to_library()` copies `library.json` from the community cache, overwriting the user's library.json that had `core: true` on some specs. When libgen runs, it preserves metadata from the freshly-copied (registry) library.json, not the user's.

## Fix

Matches the Bash version's approach (bin/akm:1542–1629):

1. **Before** copying the community cache → cold library, snapshot all core IDs from the existing `library.json`
2. **After** libgen regenerates `library.json`, restore `core: true` for the snapshotted IDs that still exist

## Changes

- Add core override snapshot/restore logic in `execute()`
- Add `core_overrides_preserved` field to `SyncReport`
- Print preservation count in `print_report()`
- Add regression test `core_overrides_preserved_across_sync`

## Testing

All 281 tests pass. `cargo clippy` and `cargo fmt --check` clean.