### PR TITLE
feat: add macOS aarch64 binary to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           sh scripts/install.sh
           echo "POSIX sh dry-run: OK"
 
-      - name: Test platform detection
+      - name: Test platform detection (Linux x86_64)
         run: |
           bash -c '
             set -euo pipefail
@@ -89,18 +89,38 @@ jobs:
             [[ "$PLATFORM" == "linux" ]]
             [[ "$ARCH" == "x86_64" ]]
             [[ "$ASSET_NAME" == "akm-linux-x86_64" ]]
-            echo "Platform detection: OK"
+            echo "Platform detection (Linux x86_64): OK"
           '
 
-      - name: Test error handling
+      - name: Test unsupported platform error
         run: |
           bash -c '
-            uname() { echo "Darwin"; }
+            uname() { echo "FreeBSD"; }
             export -f uname
             set +e
             bash scripts/install.sh 2>&1
             status=$?
             set -e
             [[ $status -ne 0 ]]
-            echo "Error handling: OK"
+            echo "Unsupported platform error: OK"
+          '
+
+      - name: Test unsupported combination error (linux-aarch64)
+        run: |
+          bash -c '
+            # Mock uname to return Linux + arm64 (no prebuilt binary)
+            uname() {
+              case "$1" in
+                -s) echo "Linux" ;;
+                -m) echo "aarch64" ;;
+                *)  command uname "$@" ;;
+              esac
+            }
+            export -f uname
+            set +e
+            bash scripts/install.sh 2>&1
+            status=$?
+            set -e
+            [[ $status -ne 0 ]]
+            echo "Unsupported combination error: OK"
           '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,41 +18,55 @@ jobs:
     uses: ./.github/workflows/ci.yml
 
   build-release:
-    name: Build release binary
+    name: Build ${{ matrix.asset }}
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            asset: akm-linux-x86_64
+            musl: true
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset: akm-macos-aarch64
+            musl: false
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-musl
+          targets: ${{ matrix.target }}
 
       - name: Install musl-tools
+        if: matrix.musl
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: release-musl
+          key: release-${{ matrix.target }}
 
-      - name: Build static binary
-        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Prepare release asset
         run: |
-          cp target/x86_64-unknown-linux-musl/release/akm akm-linux-x86_64
-          sha256sum akm-linux-x86_64 > akm-linux-x86_64.sha256
-          # Verify the binary is static
-          file akm-linux-x86_64
-          ldd akm-linux-x86_64 2>&1 || true
+          cp target/${{ matrix.target }}/release/akm ${{ matrix.asset }}
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
+          else
+            shasum -a 256 ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
+          fi
+          file ${{ matrix.asset }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-binary
+          name: release-${{ matrix.target }}
           path: |
-            akm-linux-x86_64
-            akm-linux-x86_64.sha256
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
           retention-days: 1
 
   github-release:
@@ -62,10 +76,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download artifact
+      - name: Download all release artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-binary
+          pattern: release-*
+          merge-multiple: true
 
       - name: Extract version from tag
         id: version
@@ -79,6 +94,8 @@ jobs:
           files: |
             akm-linux-x86_64
             akm-linux-x86_64.sha256
+            akm-macos-aarch64
+            akm-macos-aarch64.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,19 +31,23 @@ detect_platform() {
   arch="$(uname -m)"
 
   case "$os" in
-    Linux)  ;;
-    Darwin) error "macOS is not yet supported. Install via: cargo install akm" ;;
+    Linux)  PLATFORM="linux" ;;
+    Darwin) PLATFORM="macos" ;;
     *)      error "Unsupported OS: $os. Install via: cargo install akm" ;;
   esac
 
   case "$arch" in
-    x86_64|amd64) ;;
-    aarch64|arm64) error "ARM64 is not yet supported. Install via: cargo install akm" ;;
+    x86_64|amd64)  ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="aarch64" ;;
     *)             error "Unsupported architecture: $arch. Install via: cargo install akm" ;;
   esac
 
-  PLATFORM="linux"
-  ARCH="x86_64"
+  # Only supported combinations have release binaries
+  case "${PLATFORM}-${ARCH}" in
+    linux-x86_64|macos-aarch64) ;;
+    *) error "No prebuilt binary for ${PLATFORM}-${ARCH}. Install via: cargo install akm" ;;
+  esac
+
   ASSET_NAME="akm-${PLATFORM}-${ARCH}"
 }
 
@@ -112,17 +116,24 @@ download_and_install() {
     error "Downloaded file is too small (${file_size} bytes). The download may be corrupt."
   fi
 
-  # Verify checksum if sha256sum is available
+  # Verify checksum (sha256sum on Linux, shasum on macOS)
+  sha256_cmd=""
   if command -v sha256sum >/dev/null 2>&1; then
+    sha256_cmd="sha256sum"
+  elif command -v shasum >/dev/null 2>&1; then
+    sha256_cmd="shasum -a 256"
+  fi
+
+  if [ -n "$sha256_cmd" ]; then
     info "Verifying checksum..."
     if curl -fsSL -o "${tmpdir}/${ASSET_NAME}.sha256" "${CHECKSUM_URL}" 2>/dev/null; then
-      (cd "$tmpdir" && sha256sum -c "${ASSET_NAME}.sha256") \
+      (cd "$tmpdir" && $sha256_cmd -c "${ASSET_NAME}.sha256") \
         || error "Checksum verification failed. The download may be corrupt."
     else
       info "Warning: Checksum file not available. Skipping verification."
     fi
   else
-    info "Warning: sha256sum not found. Skipping checksum verification."
+    info "Warning: No SHA-256 tool found. Skipping checksum verification."
   fi
 
   # Install
@@ -130,6 +141,11 @@ download_and_install() {
   mv "${tmpdir}/${ASSET_NAME}" "${INSTALL_DIR}/akm" \
     || error "Failed to install binary to ${INSTALL_DIR}/akm. Check permissions."
   chmod +x "${INSTALL_DIR}/akm"
+
+  # Remove macOS quarantine attribute so Gatekeeper doesn't block execution
+  if [ "$(uname -s)" = "Darwin" ]; then
+    xattr -d com.apple.quarantine "${INSTALL_DIR}/akm" 2>/dev/null || true
+  fi
 
   info "Installed akm ${VERSION} to ${INSTALL_DIR}/akm"
 }

--- a/src/update/download.rs
+++ b/src/update/download.rs
@@ -45,9 +45,11 @@ fn resolve_download_url(config: &UpdateConfig, paths: &Paths) -> Result<(String,
     let latest = normalize_version(&release.tag_name).to_string();
     let url = release.download_url.ok_or_else(|| Error::UpdateDownload {
         url: config.url.clone(),
-        message: "No compatible binary asset found in the release. \
-                  Expected a Linux x86_64 binary."
-            .to_string(),
+        message: format!(
+            "No compatible binary asset found in the release. \
+             Expected '{}'.",
+            super::platform_asset_name()
+        ),
     })?;
 
     Ok((url, latest))
@@ -115,7 +117,7 @@ fn validate_binary(path: &Path) -> Result<()> {
         });
     }
 
-    // Check for ELF magic bytes on Linux
+    // Check magic bytes: ELF on Linux, Mach-O on macOS
     let mut file = std::fs::File::open(path).map_err(|e| Error::UpdateReplace {
         path: path.to_path_buf(),
         source: e,
@@ -128,9 +130,19 @@ fn validate_binary(path: &Path) -> Result<()> {
             source: e,
         })?;
 
-    if magic != [0x7f, b'E', b'L', b'F'] {
+    let is_valid = match () {
+        // ELF magic: 0x7f 'E' 'L' 'F'
+        _ if magic == [0x7f, b'E', b'L', b'F'] => true,
+        // Mach-O 64-bit: 0xFEEDFACF (little-endian on ARM64)
+        _ if magic == [0xCF, 0xFA, 0xED, 0xFE] => true,
+        // Mach-O universal/fat binary: 0xCAFEBABE (big-endian)
+        _ if magic == [0xCA, 0xFE, 0xBA, 0xBE] => true,
+        _ => false,
+    };
+
+    if !is_valid {
         return Err(Error::UpdateInvalidBinary {
-            reason: "file does not appear to be a valid ELF binary".to_string(),
+            reason: "file does not appear to be a valid executable binary".to_string(),
         });
     }
 

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -22,7 +22,7 @@ pub struct ReleaseInfo {
     /// The version tag (e.g., "v1.0.0" or "1.0.0").
     pub tag_name: String,
 
-    /// Direct download URL for the Linux x86_64 binary asset.
+    /// Direct download URL for the platform-specific binary asset.
     /// Populated by scanning the `assets` array for a matching filename.
     pub download_url: Option<String>,
 
@@ -41,6 +41,31 @@ pub struct CachedCheck {
 
     /// Direct download URL, if available.
     pub download_url: Option<String>,
+}
+
+/// Return the expected release asset name for the current platform.
+///
+/// Maps compile-time `target_os` and `target_arch` to the asset names
+/// produced by the release workflow (e.g., `akm-linux-x86_64`,
+/// `akm-macos-aarch64`).
+pub fn platform_asset_name() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "akm-linux-x86_64"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "akm-macos-aarch64"
+    }
+    // Fallback for unsupported platforms — the asset won't match any
+    // release artifact, so the update will report "no compatible binary".
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+    )))]
+    {
+        "akm-unsupported"
+    }
 }
 
 /// Normalize a version tag by stripping a leading "v" prefix.

--- a/src/update/version_check.rs
+++ b/src/update/version_check.rs
@@ -11,7 +11,9 @@
 
 use crate::config::UpdateConfig;
 use crate::paths::Paths;
-use crate::update::{is_newer, normalize_version, CachedCheck, ReleaseInfo, CURRENT_VERSION};
+use crate::update::{
+    is_newer, normalize_version, platform_asset_name, CachedCheck, ReleaseInfo, CURRENT_VERSION,
+};
 
 use std::sync::mpsc;
 use std::thread;
@@ -157,13 +159,12 @@ pub(crate) fn fetch_latest_release(
         .ok_or_else(|| "Missing 'tag_name' in release response".to_string())?
         .to_string();
 
-    // Find the Linux x86_64 binary asset
+    // Find the binary asset matching the current platform
+    let expected_asset = platform_asset_name();
     let download_url = body["assets"].as_array().and_then(|assets| {
         assets.iter().find_map(|asset| {
             let name = asset["name"].as_str().unwrap_or("");
-            if (name.contains("linux") && (name.contains("x86_64") || name.contains("amd64")))
-                || name == "akm"
-            {
+            if name == expected_asset || name == "akm" {
                 asset["browser_download_url"].as_str().map(String::from)
             } else {
                 None


### PR DESCRIPTION
## Summary

- Converts the release workflow's `build-release` job into a matrix (Linux x86_64 musl + macOS aarch64), building both binaries in parallel
- Updates `install.sh` to support macOS: Darwin/arm64 platform detection, `shasum -a 256` fallback for checksum verification, quarantine attribute removal
- Makes the Rust self-update (`akm update`) platform-aware: compile-time asset name matching via `platform_asset_name()`, Mach-O magic byte validation alongside ELF
- Replaces the CI "Darwin must fail" installer test with proper unsupported-platform and unsupported-combination tests

## Test plan

- [x] `cargo test` — all 158 unit tests + integration tests pass
- [x] `cargo clippy` — clean
- [x] `shellcheck -s sh scripts/install.sh` — clean
- [ ] Verify macOS build works in CI (tag a pre-release to trigger the workflow)