### PR TITLE
docs: prune stale narrative, split maintainer docs out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,20 +31,11 @@ All implementation must satisfy these criteria:
 11) Documentation (rustdoc, --help, README)
 12) ureq 3.x API patterns where applicable (match-by-value on errors, body_mut().read_json())
 
-## Supported harnesses
+## Harnesses
 
-AKM mounts the same library into several coding harnesses. The definitions live in
-`src/shell/tools.json` (embedded at compile time, written to
-`$XDG_DATA_HOME/akm/tools.json` by `akm setup`) and are loaded through
-`src/library/tool_dirs.rs`.
-
-| Harness | Command | Global dir (`ToolDef::dir`) | Staging dir | Session mount | Artifacts |
-|---------|---------|------------------------------|-------------|---------------|-----------|
-| Claude Code | `claude` | `~/.claude` | `.claude` | `--add-dir <staging>` | symlink in staging |
-| GitHub Copilot CLI | `copilot` | `~/.copilot` | `.copilot` | `--add-dir <staging>` | symlink in staging |
-| Mistral Vibe | `vibe` | `~/.vibe` | `.vibe` | none (no `--add-dir`) | none |
-| OpenCode | `opencode` | `~/.agents` | `.agents` | `OPENCODE_CONFIG_DIR` | symlink in staging |
-| Pi | `pi` | `~/.pi/agent` | `.pi` | `--skill <staging>/.pi/skills` | `--append-system-prompt` |
+Read [docs/harnesses.md](docs/harnesses.md) before changing anything under
+`src/shell/` or `src/library/tool_dirs.rs`. It carries the per-harness mount
+mechanisms and the constraints each one imposes.
 
 Three places must stay in step when a harness is added or changed:
 
@@ -54,94 +45,14 @@ Three places must stay in step when a harness is added or changed:
 3. the `case` in `_akm_wrap_tool` and the exported wrapper functions at the
    bottom of `src/shell/akm-init.sh`
 
-Note that `ToolDef::dir` is not always a single path component. Pi's global dir
-is `~/.pi/agent` but its staging dir is `.pi`, so anything writing into the
-staging tree must use `ToolDef::staging_dir()` / `ToolDirs::staging_names()`
-rather than the last component of `ToolDirs::dirs()`.
+Add a `tests/shell_test.rs` case when changing `_akm_wrap_tool`.
 
-### Pi
+## Tests
 
-Verified against pi `0.82.1` (`@earendil-works/pi-coding-agent`); docs at
-<https://pi.dev/docs/latest>.
+```bash
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt
+```
 
-- **No `--add-dir`, and none needed.** Pi does not sandbox `read`/`write`/`edit`/
-  `bash` to the working directory, so an out-of-tree path such as the artifacts
-  directory is already reachable. It only has to be named, which the wrapper does
-  with `--append-system-prompt`.
-- **`--append-system-prompt` replaces discovery.** Passing it on the CLI
-  suppresses the `APPEND_SYSTEM.md` Pi would otherwise load (project
-  `.pi/APPEND_SYSTEM.md` if trusted, else `<agent dir>/APPEND_SYSTEM.md`). The
-  wrapper re-passes that file first so it is not silently lost. The flag takes
-  literal text *or* a path to an existing file.
-- **`--skill` follows symlinks.** Pi `statSync`s symlinked entries when walking a
-  skills directory, so the AKM staging tree of symlinks works as-is.
-- **No subagents.** AKM `agents` specs have no target in Pi; only skills are
-  mounted. `<staging>/.pi/agents` is created for layout uniformity and unused.
-- **Config dir override.** `PI_CODING_AGENT_DIR` relocates `~/.pi/agent`, but
-  `auth.json`, `models-store.json` and `sessions/` live there too — do not hijack
-  it the way `OPENCODE_CONFIG_DIR` is hijacked for OpenCode.
-
-#### Pi extensions — evaluated and declined
-
-Pi is extension-first, so the obvious question is whether AKM should ship or
-depend on one. It should not, for now.
-
-- **`itisbryan/pi-add-dir`** is the community `/add-dir`. It cannot be driven at
-  launch — no flag, no env var, no settings key — and its directory list is
-  rebuilt from session entries on `session_start`, which also overwrites the
-  temp file that `resources_discover` reads. A wrapper cannot seed it. Its real
-  value is interactive *discovery* of related directories, which AKM does not
-  need: it already knows the path.
-- **A first-party AKM extension** would duplicate `--skill` via
-  `resources_discover`, and could inject the artifacts note via
-  `before_agent_start` without the `APPEND_SYSTEM.md` workaround. That is a
-  marginal gain for a TypeScript build, test and publish pipeline in a Rust repo,
-  benefiting exactly one harness.
-
-Note on `resources_discover`: it is the hook by which an *extension* contributes
-extra skill paths at startup and on `/reload`. It is not a mechanism AKM needs —
-`--skill` already puts the staging dir in front of the same loader, and `/reload`
-re-scans it.
-
-There is no capability gap to close. Mid-session re-sync — `akm skills add`
-taking effect without restarting the harness — already works:
-
-- **Claude Code** watches the skill directories with chokidar (`add`/`change`/
-  `unlink` on `*.md`, `depth: 2`, symlink-aware, `awaitWriteFinish` debounce) and
-  reloads its skill index. The watched set includes `<dir>/.claude/skills` for
-  every working directory, which is exactly what `--add-dir <staging>` gives it.
-  So AKM's staging tree is live-watched with no extra work.
-- **Pi** does not watch, but `/reload` is a built-in slash command that reloads
-  "keybindings, extensions, skills, prompts, themes, and context files".
-  `AgentSession.reload()` calls `ResourceLoader.reload()`, which re-runs
-  discovery over `additionalSkillPaths` — the `--skill` directories. One keystroke,
-  no extension.
-- **OpenCode and Copilot** are unverified. Both ship stripped/compiled binaries
-  and a strings probe found no skill watcher or reload machinery in OpenCode.
-  Treat as unknown, not as "does not work".
-
-## Supported platforms
-
-Release binaries are built for:
-- Linux x86_64 (static, musl-linked — no libc dependency)
-- macOS aarch64 (Apple Silicon)
-
-The self-update system (`akm update`) and install script both detect the current platform at runtime and select the correct asset. Platform-specific logic lives in:
-- `src/update/mod.rs` — `platform_asset_name()` (compile-time asset selection)
-- `src/update/download.rs` — `validate_binary()` (ELF + Mach-O magic byte checks)
-- `scripts/install.sh` — `detect_platform()` (runtime OS/arch detection)
-
-## Test commands
-
-- `cargo test` — unit + integration tests (`tests/`), including insta snapshots
-- `cargo clippy --all-targets -- -D warnings`
-- `cargo fmt`
-
-Snapshots live in `tests/snapshots/`. `cargo-insta` is not assumed to be
-installed; `INSTA_FORCE_UPDATE=1 cargo test --test <name>` rewrites them, and the
-diff should be reviewed before committing.
-
-`tests/shell_test.rs` drives `akm-init.sh` for real: it stubs `akm` and the
-harness binary on `PATH`, sources the script inside a temporary git repo, and
-asserts the argv the wrapper builds. Add a case there when changing
-`_akm_wrap_tool`.
+Source layout, snapshot handling and the release process: [docs/development.md](docs/development.md).

--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@ AKM wires the same library of skills, agents and instructions into every harness
 
 `akm setup` installs shell functions that shadow `claude`, `copilot`, `opencode` and `pi`. Each one builds a per-session staging directory of symlinks into the cold library, hands it to the tool in whatever form that tool understands, and tears it down on exit.
 
-### Pi specifics
+### Pi
 
-Pi is supported as a first-tier harness, with two differences from the others:
+Pi has no `--add-dir`. Session skills mount with `--skill`, and the artifacts directory — which Pi's file tools can already reach — is named in the system prompt with `--append-system-prompt`. Your own `.pi/APPEND_SYSTEM.md` (project, else `~/.pi/agent/APPEND_SYSTEM.md`) is passed alongside it.
 
-- **Skills mount with `--skill`, not `--add-dir`.** Pi has no `--add-dir` flag. `--skill` is repeatable, accepts a directory, and follows symlinked skill directories, so the standard AKM staging tree works unchanged.
-- **The artifacts directory is announced, not mounted.** Pi does not sandbox its file tools to the working directory, so the artifacts path is already reachable; the wrapper appends a short note naming it via `--append-system-prompt`. Because a CLI `--append-system-prompt` replaces the `APPEND_SYSTEM.md` Pi would otherwise discover, the wrapper re-passes that file (project `.pi/APPEND_SYSTEM.md`, else `~/.pi/agent/APPEND_SYSTEM.md`) so your own append prompt survives.
-
-Pi has no subagent concept, so AKM `agents` specs are not mounted for it — only skills. `akm instructions sync` writes global instructions to `~/.pi/agent/AGENTS.md`, and `akm skills sync` symlinks core specs into `~/.pi/agent/skills/`.
+Pi has no subagents, so only skills are mounted for it.
 
 The tool list lives in `~/.local/share/akm/tools.json` and can be edited to add harnesses without recompiling.
 
@@ -41,9 +38,7 @@ The tool list lives in `~/.local/share/akm/tools.json` and can be edited to add 
 curl -fsSL https://akm.raphaelsimon.fr/install | sh
 ```
 
-This downloads the latest release binary to `~/.local/bin/akm`. The installer auto-detects your platform and downloads the correct binary.
-
-**Supported platforms:**
+Installs the latest release binary to `~/.local/bin/akm`, detecting the platform:
 
 | Platform | Architecture | Asset |
 |----------|-------------|-------|
@@ -186,22 +181,13 @@ akm completions fish > ~/.config/fish/completions/akm.fish
 
 Config lives at `~/.config/akm/config.toml` (XDG-compliant). Created by `akm setup` or on first run with defaults.
 
-## Creating a Release
+## How a session works
 
-After merging to `main`:
-
-```bash
-git tag v1.0.0-rc1
-git push origin main --tags
-```
-
-This triggers the release workflow which:
-1. Runs all CI checks (fmt, clippy, test, build, MSRV, installer tests)
-2. Builds platform binaries in parallel:
-   - Linux x86_64 (static, musl-linked)
-   - macOS aarch64 (Apple Silicon)
-3. Creates a GitHub Release with all binaries + SHA256 checksums
-4. Publishes to crates.io (requires `CARGO_REGISTRY_TOKEN` secret)
+1. The wrapper function for a harness (`claude`, `copilot`, `opencode`, `pi`) creates a staging directory under `$XDG_CACHE_HOME/akm/<repo>-<ts>-<pid>`, with one subdirectory per harness.
+2. `akm skills session-setup` reads the project manifest (`.agents/akm.json`) and symlinks each declared spec from the cold library into every harness subdirectory.
+3. If the artifacts feature is on, the project's artifacts directory is symlinked in at the staging root and per harness — except for Pi, which is given the absolute path instead.
+4. The harness is launched with whatever flag or environment variable it uses to pick the staging tree up.
+5. On exit the staging directory is removed and artifacts are optionally committed and pushed.
 
 ## Development
 
@@ -212,46 +198,7 @@ cargo fmt --check                 # format check
 cargo build --release             # release build
 ```
 
-### Project Structure
-
-```
-src/
-├── main.rs              # Entry point, clap CLI
-├── lib.rs               # Library root
-├── config.rs            # TOML config
-├── paths.rs             # XDG path resolution
-├── error.rs             # Error hierarchy (thiserror)
-├── git.rs               # Git helper (wraps std::process::Command)
-├── github.rs            # GitHub URL parser + Contents API client
-├── editor.rs            # $EDITOR invocation
-├── commands/            # CLI command implementations
-│   ├── config.rs        # akm config
-│   ├── setup.rs         # akm setup
-│   ├── sync.rs          # akm sync
-│   ├── update.rs        # akm update
-│   ├── completions.rs   # akm completions
-│   ├── artifacts/       # akm artifacts sync
-│   ├── instructions/    # akm instructions sync/edit/scaffold-project
-│   └── skills/          # akm skills * (sync, list, import, promote, …)
-├── library/             # Spec model, libgen, manifest, symlinks, tool dirs
-├── registry/            # RegistrySource trait + GitRegistry
-├── artifacts/           # Artifact repo sync
-├── update/              # Self-update + version check
-├── completions/         # clap_complete generation + dynamic completions
-├── tui/                 # Interactive views (ratatui)
-└── shell/               # Shell init generation
-    ├── akm-init.sh      # Session lifecycle + per-harness tool wrappers
-    └── tools.json       # Harness definitions (name, command, global dir)
-```
-
-### How a session works
-
-1. The wrapper function for a harness (`claude`, `copilot`, `opencode`, `pi`) runs `_akm_session_start`.
-2. That creates a staging directory under `$XDG_CACHE_HOME/akm/<repo>-<ts>-<pid>` with one subdirectory per harness.
-3. `akm skills session-setup` reads the project manifest (`.agents/akm.json`) and symlinks each declared spec from the cold library into every harness subdirectory.
-4. If the artifacts feature is on, the project's artifacts directory is symlinked in at the staging root (and per harness), except for Pi which is given the absolute path instead.
-5. The harness is launched with whatever flag or environment variable it uses to pick the staging tree up.
-6. On exit the staging directory is removed and artifacts are optionally committed and pushed.
+See [docs/development.md](docs/development.md) for the source layout and the release process, and [docs/harnesses.md](docs/harnesses.md) for how harnesses are wired.
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,64 @@
+# Development
+
+## Source layout
+
+```
+src/
+├── main.rs              # Entry point, clap CLI
+├── lib.rs               # Library root
+├── config.rs            # TOML config
+├── paths.rs             # XDG path resolution
+├── error.rs             # Error hierarchy (thiserror)
+├── git.rs               # Git helper (wraps std::process::Command)
+├── github.rs            # GitHub URL parser + Contents API client
+├── editor.rs            # $EDITOR invocation
+├── commands/            # CLI command implementations
+├── library/             # Spec model, libgen, manifest, symlinks, tool dirs
+├── registry/            # RegistrySource trait + GitRegistry
+├── artifacts/           # Artifact repo sync
+├── update/              # Self-update + version check
+├── completions/         # Completion registration + dynamic completions
+├── tui/                 # Interactive views (ratatui)
+└── shell/               # Shell init generation
+    ├── akm-init.sh      # Session lifecycle + per-harness tool wrappers
+    └── tools.json       # Harness definitions (name, command, global dir)
+```
+
+See [harnesses.md](harnesses.md) for how `shell/` and `library/tool_dirs.rs`
+fit together.
+
+## Tests
+
+```bash
+cargo test                                 # unit + integration, including snapshots
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+Snapshots live in `tests/snapshots/`. `cargo-insta` is not assumed to be
+installed; `INSTA_FORCE_UPDATE=1 cargo test --test <name>` rewrites them, and the
+diff should be reviewed before committing.
+
+`tests/shell_test.rs` drives `akm-init.sh` for real: it stubs `akm` and the
+harness binary on `PATH`, sources the script inside a temporary git repo, and
+asserts the argv the wrapper builds.
+
+## Releasing
+
+After merging to `main`, tag and push:
+
+```bash
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+The release workflow then:
+
+1. Runs CI (fmt, clippy, test, build, MSRV, installer tests)
+2. Builds Linux x86_64 (static, musl-linked) and macOS aarch64 binaries in parallel
+3. Creates a GitHub Release with the binaries and SHA256 checksums
+4. Publishes to crates.io (requires the `CARGO_REGISTRY_TOKEN` secret)
+
+Platform selection lives in `src/update/mod.rs` (`platform_asset_name()`),
+`src/update/download.rs` (`validate_binary()`) and `scripts/install.sh`
+(`detect_platform()`).

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1,0 +1,42 @@
+# Harness wiring
+
+How AKM mounts the same library of skills, agents and instructions into each
+supported harness. Definitions live in `src/shell/tools.json` (embedded at
+compile time, written to `$XDG_DATA_HOME/akm/tools.json` by `akm setup`) and are
+loaded through `src/library/tool_dirs.rs`.
+
+| Harness | Command | Global dir (`ToolDef::dir`) | Staging dir | Session mount | Artifacts |
+|---------|---------|------------------------------|-------------|---------------|-----------|
+| Claude Code | `claude` | `~/.claude` | `.claude` | `--add-dir <staging>` | symlink in staging |
+| GitHub Copilot CLI | `copilot` | `~/.copilot` | `.copilot` | `--add-dir <staging>` | symlink in staging |
+| Mistral Vibe | `vibe` | `~/.vibe` | `.vibe` | none (no `--add-dir`) | none |
+| OpenCode | `opencode` | `~/.agents` | `.agents` | `OPENCODE_CONFIG_DIR` | symlink in staging |
+| Pi | `pi` | `~/.pi/agent` | `.pi` | `--skill <staging>/.pi/skills` | `--append-system-prompt` |
+
+## Global dir vs staging dir
+
+`ToolDef::dir` is not always a single path component — Pi's global dir is
+`~/.pi/agent` while its staging dir is `.pi`. Anything writing into the staging
+tree must use `ToolDef::staging_dir()` / `ToolDirs::staging_names()` rather than
+the last component of `ToolDirs::dirs()`.
+
+## Pi
+
+Pi CLI surface as of `0.82.1` (`@earendil-works/pi-coding-agent`); docs at
+<https://pi.dev/docs/latest>.
+
+- **No `--add-dir`, and none needed.** Pi does not sandbox `read`/`write`/`edit`/
+  `bash` to the working directory, so an out-of-tree path such as the artifacts
+  directory is already reachable. It only has to be named.
+- **`--append-system-prompt` replaces discovery.** Passing it on the CLI
+  suppresses the `APPEND_SYSTEM.md` Pi would otherwise load (project
+  `.pi/APPEND_SYSTEM.md` if trusted, else `<agent dir>/APPEND_SYSTEM.md`), so the
+  wrapper re-passes that file first. The flag takes literal text *or* a path to
+  an existing file.
+- **`--skill` follows symlinks.** Pi `statSync`s symlinked entries when walking a
+  skills directory, so the staging tree of symlinks works as-is.
+- **No subagents.** AKM `agents` specs have no target in Pi; only skills are
+  mounted. `<staging>/.pi/agents` is created for layout uniformity and unused.
+- **Do not hijack `PI_CODING_AGENT_DIR`.** It relocates `~/.pi/agent`, but
+  `auth.json`, `models-store.json` and `sessions/` live there too — unlike
+  `OPENCODE_CONFIG_DIR`, it is not free to repoint at a staging directory.

--- a/src/commands/skills/session_setup.rs
+++ b/src/commands/skills/session_setup.rs
@@ -14,8 +14,6 @@ use std::path::Path;
 
 /// Set up session staging: read manifest, create symlinks for each spec.
 ///
-/// Doing the whole manifest in one process avoids N+1 subprocess invocations
-/// from the shell init.
 /// Returns Ok(()) even on partial failures (shell init handles gracefully).
 pub fn run(paths: &Paths, staging_dir: &str, project_root: &str) -> Result<()> {
     let staging = Path::new(staging_dir);

--- a/src/completions/mod.rs
+++ b/src/completions/mod.rs
@@ -4,9 +4,6 @@
 //! command outputs a registration script that tells the shell to invoke
 //! `COMPLETE=<shell> akm` on Tab press. The binary then returns candidates
 //! (both static subcommands/flags and dynamic spec IDs).
-//!
-//! This module does NOT use `clap_complete::generate()` (the legacy AOT approach),
-//! which produces static scripts that cannot call back for dynamic completions.
 
 pub mod dynamic;
 
@@ -15,9 +12,6 @@ use crate::paths::Paths;
 use std::path::{Path, PathBuf};
 
 /// Supported shells for completion registration.
-///
-/// Uses clap's `ValueEnum` derive for CLI argument parsing, avoiding
-/// a redundant custom `from_str` implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Shell {
     Bash,

--- a/src/library/symlinks.rs
+++ b/src/library/symlinks.rs
@@ -5,8 +5,7 @@
 //! 2. **Session symlinks** — project/JIT specs symlinked into per-session staging dirs
 //! 3. **Cleanup** — remove broken symlinks, clear existing links before rebuild
 //!
-//! All symlink functions take tool dirs as a parameter (no global state).
-//! This makes them testable with temp directories.
+//! All symlink functions take tool dirs as a parameter — no global state.
 
 use crate::error::{Error, IoContext, Result};
 use crate::library::spec::{Spec, SpecType};

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -106,7 +106,6 @@ impl Paths {
     }
 
     /// `$XDG_CONFIG_HOME/akm/config.toml`
-    /// Note: Rust version uses `.toml` extension (fresh start, no migration).
     pub fn config_file(&self) -> PathBuf {
         self.config_dir.join("config.toml")
     }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -2,10 +2,8 @@
 //!
 //! AKM is a **client** of spec registries. It pulls specs from registries
 //! into the local cold library. The `RegistrySource` trait abstracts the
-//! transport mechanism (git, HTTP, local dir).
-//!
-//! Only `GitRegistry` is implemented at launch. Future backends (HTTP/REST,
-//! local directory) implement the same trait — no sync logic changes needed.
+//! transport mechanism (git, HTTP, local dir). `GitRegistry` is the only
+//! implementation.
 
 pub mod git;
 

--- a/src/shell/akm-init.sh
+++ b/src/shell/akm-init.sh
@@ -14,12 +14,11 @@
 
 # --- Config ---
 
-# Reads config via the akm binary's proper TOML parser.
-# This avoids fragile grep/sed parsing and eliminates the jq dependency.
-# Each value is cached in a shell variable for the session lifetime.
+# Reads config through the akm binary, caching each value in a shell variable
+# for the session lifetime.
 #
-# Note: `akm config <key>` prints "(not set)" for unset values.
-# We guard against this with explicit empty-check fallbacks.
+# `akm config <key>` prints "(not set)" for unset values — hence the explicit
+# empty-check fallbacks.
 _akm_load_config() {
   local raw
   raw="$(akm config features 2>/dev/null || true)"
@@ -68,16 +67,14 @@ _akm_skills_session_start() {
   local session_id="${project_name:-anon}-$(date +%s)-$$"
   local staging="${XDG_CACHE_HOME:-$HOME/.cache}/akm/$session_id"
 
-  # Create staging directory structure.
-  # Pi is included: it has no subagent concept, but keeping the layout uniform
-  # keeps this in step with `akm skills load`, which creates both subdirs.
+  # Create staging directory structure. Pi gets an agents/ subdir it never
+  # reads, so the layout matches `akm skills load`, which creates both.
   local tool_dir
   for tool_dir in .claude .copilot .agents .pi; do
     mkdir -p "$staging/$tool_dir"/{skills,agents}
   done
 
-  # Delegate all manifest loading and symlink creation to the Rust binary
-  # in a single process invocation (avoids N+1 subprocess overhead).
+  # Manifest loading and symlink creation happen in one binary invocation.
   akm skills session-setup "$staging" "$project_root" 2>/dev/null || true
 
   export AKM_SESSION="$staging"
@@ -162,12 +159,10 @@ _akm_session_start() {
     fi
   fi
 
-  # Bridge artifacts into the staging tree via symlinks.
-  # A top-level artifacts/ symlink makes the path obvious to LLMs
-  # (they see the staging root as an "additional working directory").
-  # Per-tool symlinks are kept for tools that only read their own subdir.
-  # Pi is excluded: it never reads the staging root, and it is told the
-  # artifact dir by absolute path instead (see the `pi)` branch below).
+  # Bridge artifacts into the staging tree via symlinks: one at the root, where
+  # a tool given the staging dir as a working directory will see it, and one per
+  # tool for those that only read their own subdir. Pi reads neither — it is
+  # told the artifact dir by absolute path instead (see the `pi)` branch below).
   if [[ -n "$artifact_dir" && -n "$staging_dir" ]]; then
     ln -sfn "$artifact_dir" "$staging_dir/artifacts"
     local tool_dir
@@ -221,9 +216,6 @@ _akm_pi_append_file() {
 }
 
 # The artifacts announcement appended to Pi's system prompt.
-#
-# Pi has no --add-dir, and needs none: its tools are not sandboxed to the
-# working directory. The artifacts dir only has to be named.
 _akm_pi_artifacts_prompt() {
   cat <<EOF
 ## AKM artifacts directory
@@ -255,9 +247,9 @@ _akm_wrap_tool() {
       fi
       ;;
     pi)
-      # Pi has no --add-dir. Session skills mount explicitly with --skill
-      # (repeatable, and Pi follows symlinked skill directories); the artifacts
-      # dir is announced in the system prompt rather than mounted.
+      # Pi has no --add-dir. Skills mount with --skill (repeatable, and Pi
+      # follows symlinked skill directories); the artifacts dir is announced in
+      # the system prompt rather than mounted.
       if [[ -n "${_AKM_STAGING_DIR:-}" && -d "${_AKM_STAGING_DIR}/.pi/skills" ]]; then
         cmd+=(--skill "${_AKM_STAGING_DIR}/.pi/skills")
       fi
@@ -269,9 +261,9 @@ _akm_wrap_tool() {
       fi
       ;;
     *)
-      # claude, copilot, vibe support --add-dir.
-      # Artifacts are symlinked into the staging dir, so one dir is enough.
-      # If only artifacts (no skills/staging), pass the artifact dir directly.
+      # claude and copilot support --add-dir. Artifacts are symlinked into the
+      # staging dir, so one dir is enough; with artifacts but no staging dir,
+      # pass the artifact dir directly.
       if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
         cmd+=(--add-dir "$_AKM_STAGING_DIR")
       elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
@@ -291,10 +283,7 @@ _akm_wrap_tool() {
 }
 
 # --- Exported wrappers ---
-# claude, copilot get the staging dir (which includes artifacts via symlink)
-# with --add-dir; opencode uses OPENCODE_CONFIG_DIR; pi uses --skill plus a
-# system-prompt note naming the artifacts dir.
-# Vibe is excluded (doesn't support --add-dir).
+# Vibe is excluded — it has no --add-dir, so there is nothing to wrap.
 
 claude()   { _akm_wrap_tool claude   "$@"; }
 copilot()  { _akm_wrap_tool copilot  "$@"; }

--- a/src/tui/edit.rs
+++ b/src/tui/edit.rs
@@ -2,7 +2,6 @@
 //!
 //! Opened by pressing `e` in the list view. Unlike `akm skills edit` which
 //! opens $EDITOR on raw JSON, this provides a structured form-like interface.
-//! Triggers editing is deferred (read-only structured data).
 
 use crate::error::Result;
 use crate::tui::app::App;

--- a/tests/snapshots/shell_test__shell_init.snap
+++ b/tests/snapshots/shell_test__shell_init.snap
@@ -18,12 +18,11 @@ expression: "akm::shell::shell_init_content()"
 
 # --- Config ---
 
-# Reads config via the akm binary's proper TOML parser.
-# This avoids fragile grep/sed parsing and eliminates the jq dependency.
-# Each value is cached in a shell variable for the session lifetime.
+# Reads config through the akm binary, caching each value in a shell variable
+# for the session lifetime.
 #
-# Note: `akm config <key>` prints "(not set)" for unset values.
-# We guard against this with explicit empty-check fallbacks.
+# `akm config <key>` prints "(not set)" for unset values — hence the explicit
+# empty-check fallbacks.
 _akm_load_config() {
   local raw
   raw="$(akm config features 2>/dev/null || true)"
@@ -72,16 +71,14 @@ _akm_skills_session_start() {
   local session_id="${project_name:-anon}-$(date +%s)-$$"
   local staging="${XDG_CACHE_HOME:-$HOME/.cache}/akm/$session_id"
 
-  # Create staging directory structure.
-  # Pi is included: it has no subagent concept, but keeping the layout uniform
-  # keeps this in step with `akm skills load`, which creates both subdirs.
+  # Create staging directory structure. Pi gets an agents/ subdir it never
+  # reads, so the layout matches `akm skills load`, which creates both.
   local tool_dir
   for tool_dir in .claude .copilot .agents .pi; do
     mkdir -p "$staging/$tool_dir"/{skills,agents}
   done
 
-  # Delegate all manifest loading and symlink creation to the Rust binary
-  # in a single process invocation (avoids N+1 subprocess overhead).
+  # Manifest loading and symlink creation happen in one binary invocation.
   akm skills session-setup "$staging" "$project_root" 2>/dev/null || true
 
   export AKM_SESSION="$staging"
@@ -166,12 +163,10 @@ _akm_session_start() {
     fi
   fi
 
-  # Bridge artifacts into the staging tree via symlinks.
-  # A top-level artifacts/ symlink makes the path obvious to LLMs
-  # (they see the staging root as an "additional working directory").
-  # Per-tool symlinks are kept for tools that only read their own subdir.
-  # Pi is excluded: it never reads the staging root, and it is told the
-  # artifact dir by absolute path instead (see the `pi)` branch below).
+  # Bridge artifacts into the staging tree via symlinks: one at the root, where
+  # a tool given the staging dir as a working directory will see it, and one per
+  # tool for those that only read their own subdir. Pi reads neither — it is
+  # told the artifact dir by absolute path instead (see the `pi)` branch below).
   if [[ -n "$artifact_dir" && -n "$staging_dir" ]]; then
     ln -sfn "$artifact_dir" "$staging_dir/artifacts"
     local tool_dir
@@ -225,9 +220,6 @@ _akm_pi_append_file() {
 }
 
 # The artifacts announcement appended to Pi's system prompt.
-#
-# Pi has no --add-dir, and needs none: its tools are not sandboxed to the
-# working directory. The artifacts dir only has to be named.
 _akm_pi_artifacts_prompt() {
   cat <<EOF
 ## AKM artifacts directory
@@ -259,9 +251,9 @@ _akm_wrap_tool() {
       fi
       ;;
     pi)
-      # Pi has no --add-dir. Session skills mount explicitly with --skill
-      # (repeatable, and Pi follows symlinked skill directories); the artifacts
-      # dir is announced in the system prompt rather than mounted.
+      # Pi has no --add-dir. Skills mount with --skill (repeatable, and Pi
+      # follows symlinked skill directories); the artifacts dir is announced in
+      # the system prompt rather than mounted.
       if [[ -n "${_AKM_STAGING_DIR:-}" && -d "${_AKM_STAGING_DIR}/.pi/skills" ]]; then
         cmd+=(--skill "${_AKM_STAGING_DIR}/.pi/skills")
       fi
@@ -273,9 +265,9 @@ _akm_wrap_tool() {
       fi
       ;;
     *)
-      # claude, copilot, vibe support --add-dir.
-      # Artifacts are symlinked into the staging dir, so one dir is enough.
-      # If only artifacts (no skills/staging), pass the artifact dir directly.
+      # claude and copilot support --add-dir. Artifacts are symlinked into the
+      # staging dir, so one dir is enough; with artifacts but no staging dir,
+      # pass the artifact dir directly.
       if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
         cmd+=(--add-dir "$_AKM_STAGING_DIR")
       elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
@@ -295,10 +287,7 @@ _akm_wrap_tool() {
 }
 
 # --- Exported wrappers ---
-# claude, copilot get the staging dir (which includes artifacts via symlink)
-# with --add-dir; opencode uses OPENCODE_CONFIG_DIR; pi uses --skill plus a
-# system-prompt note naming the artifacts dir.
-# Vibe is excluded (doesn't support --add-dir).
+# Vibe is excluded — it has no --add-dir, so there is nothing to wrap.
 
 claude()   { _akm_wrap_tool claude   "$@"; }
 copilot()  { _akm_wrap_tool copilot  "$@"; }


### PR DESCRIPTION
## What

The Pi harness work left the documentation carrying its own history — what was evaluated and declined, what a flag *would otherwise* have done, which approach was not taken. This strips the docs back to a description of the tool as it currently is.

**239 lines removed, 168 added** — and 106 of those additions are the two new `docs/` pages that content was *moved* into.

## README

- `### Pi specifics` → `### Pi`, cut to what a user acts on. Gone: "supported as a first-tier harness", the restatement of the table, and the paragraph on why `--append-system-prompt` re-passes `APPEND_SYSTEM.md`. Kept: the fact that your own append prompt still gets passed.
- `## Creating a Release` and `### Project Structure` moved to `docs/development.md`. The release snippet no longer hardcodes `v1.0.0-rc1`.
- `### How a session works` stays, trimmed by a step.

## AGENTS.md — 113 lines → 60

Per the principle that AGENTS.md carries the minimum an agent needs to avoid repeating a known mistake, and deeper material is discovered on demand:

- **Removed entirely**: the "Pi extensions — evaluated and declined" section and the mid-session re-sync research (chokidar internals, `/reload`, `resources_discover`). It is a decision record, not an instruction.
- **Moved to `docs/harnesses.md`**: the internals table and the four Pi constraints an agent could actually violate. AGENTS.md links to it from a one-line pointer.
- **Kept**: tech stack, review criteria, the three-places-must-stay-in-step checklist, test commands.

## Code comments

Three patterns cut:

| Pattern | Example |
|---|---|
| Past-state | `paths.rs` — "Rust version uses `.toml` (fresh start, no migration)", referring to the retired Bash tool |
| Why-we-didn't-do-X | `completions/mod.rs` — "does NOT use `clap_complete::generate()` (the legacy AOT approach)" |
| Self-assessment | `symlinks.rs` — "This makes them testable with temp directories" |

Also deleted `tui/edit.rs`'s "Triggers editing is deferred (read-only structured data)", which parses as nothing.

## One correctness fix

`akm-init.sh`'s `*)` branch comment claimed to serve "claude, copilot, vibe". Vibe has no wrapper and never reaches that branch.

## Verification

`cargo test` (all suites pass), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean. `tests/snapshots/shell_test__shell_init.snap` regenerated for the comment edits and reviewed.

Companion PR on akm-web corrects the website, which was describing the pre-Pi world.