### PR TITLE
fix: stop session staging dir from eating agent output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,10 @@ Three places must stay in step when a harness is added or changed:
 
 1. `src/shell/tools.json` + `builtin_tools()` in `src/library/tool_dirs.rs`
 2. the staging-dir loop in `src/commands/skills/session_setup.rs` **and** the
-   matching loop in `src/shell/akm-init.sh` (`_akm_skills_session_start`)
+   two matching loops in `src/shell/akm-init.sh` — `_akm_skills_session_start`
+   (creates them) and `_akm_skills_session_end` (removes them). Teardown
+   removes only the dirs it knows about, so a dir missing from the second loop
+   is left behind and quarantined as a stray on every session.
 3. the `case` in `_akm_wrap_tool` and the exported wrapper functions at the
    bottom of `src/shell/akm-init.sh`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AKM wires the same library of skills, agents and instructions into every harness
 
 | Harness | Command | Global dir | Session mount | Artifacts |
 |---------|---------|------------|---------------|-----------|
-| [Claude Code](https://claude.ai/code) | `claude` | `~/.claude` | `--add-dir <staging>` | symlinked into staging |
+| [Claude Code](https://claude.ai/code) | `claude` | `~/.claude` | `--add-dir <staging>` | symlinked into staging, named in the system prompt |
 | [GitHub Copilot CLI](https://github.com/features/copilot) | `copilot` | `~/.copilot` | `--add-dir <staging>` | symlinked into staging |
 | [OpenCode](https://opencode.ai) | `opencode` | `~/.agents` | `OPENCODE_CONFIG_DIR` | symlinked into staging |
 | [Pi](https://pi.dev) | `pi` | `~/.pi/agent` | `--skill <staging>/.pi/skills` | named in the system prompt |
@@ -169,6 +169,9 @@ akm update                       # download and install latest version
 akm update --check               # check without installing
 ```
 
+`akm update` also rewrites `akm-init.sh` from the new binary, so shell-side
+changes land without a second `akm setup`. Restart your shell to pick them up.
+
 ### Shell Completions
 
 ```bash
@@ -186,8 +189,9 @@ Config lives at `~/.config/akm/config.toml` (XDG-compliant). Created by `akm set
 1. The wrapper function for a harness (`claude`, `copilot`, `opencode`, `pi`) creates a staging directory under `$XDG_CACHE_HOME/akm/<repo>-<ts>-<pid>`, with one subdirectory per harness.
 2. `akm skills session-setup` reads the project manifest (`.agents/akm.json`) and symlinks each declared spec from the cold library into every harness subdirectory.
 3. If the artifacts feature is on, the project's artifacts directory is symlinked in at the staging root and per harness — except for Pi, which is given the absolute path instead.
-4. The harness is launched with whatever flag or environment variable it uses to pick the staging tree up.
-5. On exit the staging directory is removed and artifacts are optionally committed and pushed.
+4. A `README.md` naming the artifacts directory is written at the staging root, and the root is made read-only. The staging tree is deleted on exit, so a write landing there would be lost; the harness sees a permission error instead.
+5. The harness is launched with whatever flag or environment variable it uses to pick the staging tree up. Harnesses that accept a system prompt (`claude`, `pi`) are also told the artifacts path outright.
+6. On exit the staging directory is removed and artifacts are optionally committed and pushed. Anything AKM did not create is moved to `<artifacts>/<repo>/orphaned/<session>/` rather than deleted, and the next session tells its agent to triage it.
 
 ## Development
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -7,11 +7,42 @@ loaded through `src/library/tool_dirs.rs`.
 
 | Harness | Command | Global dir (`ToolDef::dir`) | Staging dir | Session mount | Artifacts |
 |---------|---------|------------------------------|-------------|---------------|-----------|
-| Claude Code | `claude` | `~/.claude` | `.claude` | `--add-dir <staging>` | symlink in staging |
+| Claude Code | `claude` | `~/.claude` | `.claude` | `--add-dir <staging>` | symlink + `--append-system-prompt` |
 | GitHub Copilot CLI | `copilot` | `~/.copilot` | `.copilot` | `--add-dir <staging>` | symlink in staging |
 | Mistral Vibe | `vibe` | `~/.vibe` | `.vibe` | none (no `--add-dir`) | none |
 | OpenCode | `opencode` | `~/.agents` | `.agents` | `OPENCODE_CONFIG_DIR` | symlink in staging |
 | Pi | `pi` | `~/.pi/agent` | `.pi` | `--skill <staging>/.pi/skills` | `--append-system-prompt` |
+
+## The staging dir is ephemeral, the artifacts dir is not
+
+Harnesses that take `--add-dir` are handed the staging dir, which is destroyed
+at session end. Agents are told to put non-code outputs in "the additional
+working directory" — so left to itself that instruction points them at a
+directory that will be deleted under them. That cost a user ~700 lines of
+research output (issue #23). Four things guard it, in order of when they fire:
+
+1. **Named.** Harnesses with a system-prompt flag (`claude`, `pi`) get the
+   artifacts dir by resolved absolute path via `_akm_artifacts_prompt`. A
+   literal path is far more reliable than a rule for deriving one, and the
+   symlink only makes the durable path *reachable*, never *obvious*.
+2. **Signposted.** `<staging>/README.md` says the same thing, for the harnesses
+   with no system-prompt flag (`copilot`, `opencode`).
+3. **Sealed.** The staging *root* is `chmod a-w` after setup, so a stray write
+   fails with EACCES the agent sees as a tool error and can correct, instead of
+   succeeding and vanishing later. Tool subdirs stay writable — `opencode`
+   keeps state in the one `OPENCODE_CONFIG_DIR` points at.
+4. **Rescued.** Teardown removes only the dirs it created, then `rmdir`s the
+   parent. If that fails, something unexpected is inside: it moves to
+   `<artifacts>/<repo>/orphaned/<session_id>/` (git-synced, so it is committed
+   on the way out) and the next session's system prompt tells the agent to
+   triage it. The agent that wrote the files is gone by then, so the next one
+   is the first that can act.
+
+There is deliberately no watcher process. Nothing outside a live agent can
+reach its context — terminal output is not something the model sees, only tool
+results are — so the filesystem's own EACCES is the only in-band, harness-
+agnostic write-time signal available. `inotify` would also breach the
+no-runtime-dependencies rule.
 
 ## Global dir vs staging dir
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,12 @@ enum Commands {
     Sync,
     /// Pull latest and re-install
     Update,
+    /// [hidden] Rewrite akm-init.sh and tools.json from this binary
+    ///
+    /// Invoked by `akm update` on the *new* binary after the swap: the running
+    /// process embeds the old template, so it cannot refresh the script itself.
+    #[command(hide = true, name = "shell-install")]
+    ShellInstall,
     /// Skills management
     Skills {
         #[command(subcommand)]
@@ -292,6 +298,8 @@ fn main() -> ExitCode {
             Ok(cfg) => commands::update::run(&paths, &cfg),
             Err(e) => Err(e),
         },
+        Some(Commands::ShellInstall) => akm::shell::install_shell_init(&paths)
+            .and_then(|()| akm::shell::install_tools_json(&paths)),
         Some(Commands::Skills { command }) => {
             let tool_dirs = akm::library::tool_dirs::ToolDirs::load(&paths);
 

--- a/src/shell/akm-init.sh
+++ b/src/shell/akm-init.sh
@@ -81,10 +81,81 @@ _akm_skills_session_start() {
 }
 
 _akm_skills_session_end() {
-  if [[ -n "${AKM_SESSION:-}" && -d "$AKM_SESSION" ]]; then
-    rm -rf "$AKM_SESSION"
+  if [[ -z "${AKM_SESSION:-}" || ! -d "$AKM_SESSION" ]]; then
+    unset AKM_SESSION
+    return 0
   fi
+
+  # The root was sealed in _akm_session_start — reopen it so its entries can go.
+  chmod u+w "$AKM_SESSION" 2>/dev/null || true
+
+  # Remove only what session start created. Anything else is a stray write and
+  # has to survive, so the parent goes with rmdir rather than rm -rf.
+  rm -f "$AKM_SESSION/artifacts" "$AKM_SESSION/README.md"
+  local tool_dir
+  for tool_dir in .claude .copilot .agents .pi; do
+    rm -rf "${AKM_SESSION:?}/$tool_dir"
+  done
+
+  if ! rmdir "$AKM_SESSION" 2>/dev/null; then
+    _akm_quarantine_staging
+  fi
+
   unset AKM_SESSION
+}
+
+# Rescue stray files from a staging dir instead of deleting them.
+#
+# Only reached when rmdir found something session start did not create. With
+# artifacts enabled the files move into the artifacts dir, which is git-synced,
+# so _akm_session_end commits them on the way out. Without it there is no
+# durable location, so the staging dir is left on disk rather than removed.
+_akm_quarantine_staging() {
+  if [[ -z "${_AKM_ARTIFACT_DIR:-}" ]]; then
+    echo "akm: kept $AKM_SESSION — it holds files akm did not create" >&2
+    return 0
+  fi
+
+  local dest="$_AKM_ARTIFACT_DIR/orphaned/$(basename "$AKM_SESSION")"
+  if ! mkdir -p "$dest" 2>/dev/null; then
+    echo "akm: kept $AKM_SESSION — could not create $dest" >&2
+    return 0
+  fi
+
+  # -mindepth 1 also catches dotfiles, which a bare glob would miss.
+  find "$AKM_SESSION" -mindepth 1 -maxdepth 1 -exec mv {} "$dest/" \; 2>/dev/null
+
+  # rmdir is the real test: find's exit code says nothing about whether the
+  # individual mv calls succeeded.
+  if rmdir "$AKM_SESSION" 2>/dev/null; then
+    echo "akm: rescued stray session files -> $dest" >&2
+  else
+    echo "akm: kept $AKM_SESSION — could not rescue all of its files" >&2
+  fi
+}
+
+# Signpost for an agent that lists the staging root looking for somewhere to
+# write. Tools that take a system prompt are told the same thing directly (see
+# _akm_artifacts_prompt); this covers the ones that do not.
+_akm_write_staging_readme() {
+  local staging="$1"
+  local artifact_dir="$2"
+
+  {
+    echo "# AKM session staging — EPHEMERAL"
+    echo
+    echo "This directory is deleted when the shell session ends, and its root is"
+    echo "read-only. Do not write here."
+    if [[ -n "$artifact_dir" ]]; then
+      echo
+      echo "Durable outputs — plans/, research/, sessions/, prompts/, archive/ —"
+      echo "belong in the artifacts directory:"
+      echo
+      echo "    $artifact_dir"
+      echo
+      echo "reachable from this directory as ./artifacts/"
+    fi
+  } >"$staging/README.md" 2>/dev/null || true
 }
 
 # --- Artifacts lifecycle ---
@@ -171,6 +242,17 @@ _akm_session_start() {
     done
   fi
 
+  # Seal the staging root. Tools are handed this directory as a working
+  # directory, and the tree is removed on session end — so a stray write here
+  # is silent data loss. Denying writes at the root turns that into an
+  # immediate EACCES the agent sees as a tool error and can act on. Only the
+  # root is sealed; the tool subdirs stay writable for tools that keep state
+  # in them (opencode's OPENCODE_CONFIG_DIR points at one).
+  if [[ -n "$staging_dir" ]]; then
+    _akm_write_staging_readme "$staging_dir" "$artifact_dir"
+    chmod a-w "$staging_dir" 2>/dev/null || true
+  fi
+
   # Export for use in _akm_session_end and _akm_wrap_tool
   export _AKM_ARTIFACT_DIR="${artifact_dir}"
   export _AKM_STAGING_DIR="${staging_dir}"
@@ -215,8 +297,13 @@ _akm_pi_append_file() {
   fi
 }
 
-# The artifacts announcement appended to Pi's system prompt.
-_akm_pi_artifacts_prompt() {
+# --- System prompt announcement ---
+
+# The artifacts announcement, appended to the system prompt of tools that
+# accept one (claude, pi). Naming the resolved absolute path is what makes the
+# durable location unambiguous — an agent given only the staging dir has to
+# infer where artifacts go, and inferring wrong used to cost it its output.
+_akm_artifacts_prompt() {
   cat <<EOF
 ## AKM artifacts directory
 
@@ -226,6 +313,31 @@ That absolute path is this project's AKM artifacts directory. It lives outside
 the repository and holds non-code outputs: plans/, research/, sessions/,
 prompts/, archive/. Write plans, research and session notes there rather than
 into the repository, and read from it with absolute paths.
+
+Never write into the AKM session staging directory — the ephemeral path some
+tools receive as an additional working directory. It is deleted when the shell
+session ends, and its root is read-only to enforce that.
+EOF
+  _akm_orphaned_notice
+}
+
+# Tell the agent about files rescued from an earlier session's staging dir.
+#
+# The rescue happens at session end, when the agent that wrote them is already
+# gone — so the next one is the first that can act on it.
+_akm_orphaned_notice() {
+  local orphaned="$_AKM_ARTIFACT_DIR/orphaned"
+  [[ -d "$orphaned" && -n "$(ls -A "$orphaned" 2>/dev/null)" ]] || return 0
+
+  cat <<EOF
+
+### Rescued files awaiting triage
+
+$orphaned
+
+An earlier session wrote files into its staging directory, which is ephemeral.
+They were moved here rather than deleted. Review them, file them properly under
+the artifacts directory, and remove the rescued copies once done.
 EOF
 }
 
@@ -257,13 +369,28 @@ _akm_wrap_tool() {
         local pi_append
         pi_append="$(_akm_pi_append_file)"
         [[ -n "$pi_append" ]] && cmd+=(--append-system-prompt "$pi_append")
-        cmd+=(--append-system-prompt "$(_akm_pi_artifacts_prompt)")
+        cmd+=(--append-system-prompt "$(_akm_artifacts_prompt)")
+      fi
+      ;;
+    claude)
+      # Claude Code takes both flags: --add-dir mounts the staging tree, and
+      # the appended prompt names the artifacts dir by absolute path. The
+      # symlink alone is not enough — it makes the durable path reachable, not
+      # obvious, and the staging root it sits in is ephemeral.
+      if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
+        cmd+=(--add-dir "$_AKM_STAGING_DIR")
+      elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
+        cmd+=(--add-dir "$_AKM_ARTIFACT_DIR")
+      fi
+      if [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
+        cmd+=(--append-system-prompt "$(_akm_artifacts_prompt)")
       fi
       ;;
     *)
-      # claude and copilot support --add-dir. Artifacts are symlinked into the
-      # staging dir, so one dir is enough; with artifacts but no staging dir,
-      # pass the artifact dir directly.
+      # copilot supports --add-dir but has no --append-system-prompt, so it
+      # relies on the staging README and the read-only root instead. Artifacts
+      # are symlinked into the staging dir, so one dir is enough; with
+      # artifacts but no staging dir, pass the artifact dir directly.
       if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
         cmd+=(--add-dir "$_AKM_STAGING_DIR")
       elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then

--- a/src/update/download.rs
+++ b/src/update/download.rs
@@ -5,6 +5,7 @@
 //! 2. Download the binary to a temporary file in the same directory as self
 //! 3. Set executable permissions on the temp file
 //! 4. Atomically rename the temp file over the current binary
+//! 5. Invoke the new binary to rewrite the shell init it embeds
 //!
 //! Placing the temp file in the same directory guarantees `rename(2)` is
 //! atomic (same filesystem). If anything fails, the temp file is cleaned up
@@ -17,6 +18,7 @@ use crate::update::version_check;
 use crate::update::{is_newer, normalize_version, CachedCheck, CURRENT_VERSION};
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 /// Minimum valid binary size (64 KB). Anything smaller is almost certainly
@@ -231,6 +233,14 @@ pub fn download_and_replace(config: &UpdateConfig, paths: &Paths) -> Result<()> 
     };
     version_check::write_cache(paths, &cached);
 
+    // Step 8: Refresh the shell init from the binary just installed.
+    //
+    // akm-init.sh is embedded at compile time, so this process holds the *old*
+    // copy — it has to be the new binary that writes it. Without this the
+    // script stays at whatever version last ran `akm setup`, and shell-side
+    // fixes never reach users who update with `akm update`.
+    refresh_shell_init(&self_path);
+
     println!("Updated akm: {current} → {latest_version}");
     println!("Restart your shell or run `akm --version` to verify.");
 
@@ -238,6 +248,19 @@ pub fn download_and_replace(config: &UpdateConfig, paths: &Paths) -> Result<()> 
     cleanup.defuse();
 
     Ok(())
+}
+
+/// Ask the newly installed binary to rewrite `akm-init.sh` and `tools.json`.
+///
+/// Non-fatal: the binary swap already succeeded, so a failure here must not
+/// fail the update. It is reported so the user knows to run `akm setup`.
+fn refresh_shell_init(self_path: &Path) {
+    let outcome = Command::new(self_path).arg("shell-install").status();
+
+    match outcome {
+        Ok(status) if status.success() => println!("Refreshed shell init."),
+        _ => eprintln!("Warning: could not refresh shell init — run `akm setup` to update it."),
+    }
 }
 
 /// RAII guard to clean up the temp file if an error occurs.

--- a/tests/shell_test.rs
+++ b/tests/shell_test.rs
@@ -1,5 +1,8 @@
 //! Integration tests for shell init generation.
 
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
 /// Verify the embedded akm-init.sh is valid bash syntax
 #[test]
 fn test_shell_init_syntax_check() {
@@ -29,28 +32,30 @@ fn test_shell_init_snapshot() {
     insta::assert_snapshot!("shell_init", akm::shell::shell_init_content());
 }
 
-/// Drive the `pi` wrapper end to end and capture the argv it builds.
+/// A sourced akm-init.sh with stubbed `akm` and stubbed tools.
 ///
-/// Stubs `akm`, `git` is real (a temp repo is initialised), and `pi` is a
-/// script that dumps its arguments one per line.
-fn run_pi_wrapper() -> String {
-    use std::process::Command;
+/// Tools are scripts that dump their argv (and, for `claude`, a probe of the
+/// staging dir) into files under the temp root, so a test can assert on what
+/// the wrapper built and on what the agent would have seen mid-session.
+struct Harness {
+    dir: tempfile::TempDir,
+}
 
-    let dir = tempfile::tempdir().unwrap();
-    let root = dir.path();
+impl Harness {
+    fn new() -> Self {
+        let h = Harness {
+            dir: tempfile::tempdir().unwrap(),
+        };
+        let root = h.dir.path();
 
-    let stubs = root.join("stubs");
-    std::fs::create_dir_all(&stubs).unwrap();
+        let stubs = root.join("stubs");
+        std::fs::create_dir_all(&stubs).unwrap();
+        std::fs::create_dir_all(h.artifacts()).unwrap();
 
-    let artifacts = root.join("artifacts");
-    std::fs::create_dir_all(&artifacts).unwrap();
-
-    let argv_file = root.join("pi-argv.txt");
-
-    write_stub(
-        &stubs.join("akm"),
-        &format!(
-            r#"#!/bin/bash
+        write_stub(
+            &stubs.join("akm"),
+            &format!(
+                r#"#!/bin/bash
 case "$1 $2" in
   "config features") echo "skills,artifacts" ;;
   "config artifacts.dir") echo "{}" ;;
@@ -58,65 +63,121 @@ case "$1 $2" in
 esac
 exit 0
 "#,
-            artifacts.display()
-        ),
-    );
+                h.artifacts().display()
+            ),
+        );
 
-    write_stub(
-        &stubs.join("pi"),
-        &format!(
-            "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"{}\"\n",
-            argv_file.display()
-        ),
-    );
+        // Pi only needs to record argv.
+        write_stub(
+            &stubs.join("pi"),
+            &format!(
+                "#!/bin/bash\nprintf '%s\\n' \"$@\" > \"{}\"\n",
+                h.probe("pi-argv").display()
+            ),
+        );
 
-    let project = root.join("myrepo");
-    std::fs::create_dir_all(&project).unwrap();
-    let init_path = root.join("akm-init.sh");
-    std::fs::write(&init_path, include_str!("../src/shell/akm-init.sh")).unwrap();
+        // Claude additionally probes the session dir it was handed: what the
+        // staging root contains, whether a stray write there succeeds, and
+        // whether the signpost is readable.
+        write_stub(
+            &stubs.join("claude"),
+            &format!(
+                r#"#!/bin/bash
+printf '%s\n' "$@" > "{argv}"
+ls -A "$AKM_SESSION" > "{ls}" 2>&1
+if mkdir "$AKM_SESSION/research" 2>"{stray}"; then
+  echo "STRAY WRITE SUCCEEDED" >> "{stray}"
+fi
+cat "$AKM_SESSION/README.md" > "{readme}" 2>&1
+"#,
+                argv = h.probe("claude-argv").display(),
+                ls = h.probe("staging-ls").display(),
+                stray = h.probe("stray-write").display(),
+                readme = h.probe("readme").display(),
+            ),
+        );
 
-    // No `set -e`: akm-init.sh is written for interactive shells and relies on
-    // functions returning non-zero (see the note at the top of the script).
-    let script = format!(
-        r#"export PATH="{stubs}:$PATH"
+        std::fs::create_dir_all(root.join("myrepo")).unwrap();
+        std::fs::write(
+            root.join("akm-init.sh"),
+            include_str!("../src/shell/akm-init.sh"),
+        )
+        .unwrap();
+
+        h
+    }
+
+    /// The configured artifacts root (`artifacts.dir`).
+    fn artifacts(&self) -> PathBuf {
+        self.dir.path().join("artifacts")
+    }
+
+    /// This project's artifacts dir — where rescued files land.
+    fn artifact_dir(&self) -> PathBuf {
+        self.artifacts().join("myrepo")
+    }
+
+    fn probe(&self, name: &str) -> PathBuf {
+        self.dir.path().join(name)
+    }
+
+    fn read_probe(&self, name: &str) -> String {
+        std::fs::read_to_string(self.probe(name))
+            .unwrap_or_else(|e| panic!("probe '{name}' was never written: {e}"))
+    }
+
+    /// Source akm-init.sh in a repo-rooted shell and run `body`.
+    ///
+    /// No `set -e`: akm-init.sh is written for interactive shells and relies on
+    /// functions returning non-zero (see the note at the top of the script).
+    fn run(&self, body: &str) -> Output {
+        use std::process::Command;
+
+        let root = self.dir.path();
+        let script = format!(
+            r#"export PATH="{stubs}:$PATH"
 export XDG_CACHE_HOME="{cache}"
 cd "{project}"
 git init -q .
 source "{init}"
-pi --model sonnet
+{body}
 "#,
-        stubs = stubs.display(),
-        cache = root.join("cache").display(),
-        project = project.display(),
-        init = init_path.display(),
-    );
+            stubs = root.join("stubs").display(),
+            cache = root.join("cache").display(),
+            project = root.join("myrepo").display(),
+            init = root.join("akm-init.sh").display(),
+        );
 
-    let output = Command::new("bash")
-        .arg("-c")
-        .arg(&script)
-        .env("HOME", root)
-        .output()
-        .expect("bash not found");
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(&script)
+            .env("HOME", root)
+            .output()
+            .expect("bash not found");
 
-    assert!(
-        output.status.success(),
-        "wrapper script failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    std::fs::read_to_string(&argv_file).expect("pi stub was never invoked")
+        assert!(
+            output.status.success(),
+            "wrapper script failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
 }
 
-fn write_stub(path: &std::path::Path, body: &str) {
+fn write_stub(path: &Path, body: &str) {
     use std::os::unix::fs::PermissionsExt;
     std::fs::write(path, body).unwrap();
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
 
+// --- Pi wrapper ---
+
 /// The `pi` wrapper mounts session skills with `--skill`, not `--add-dir`.
 #[test]
 fn test_pi_wrapper_mounts_skills_dir() {
-    let argv = run_pi_wrapper();
+    let h = Harness::new();
+    h.run("pi --model sonnet");
+    let argv = h.read_probe("pi-argv");
     let lines: Vec<&str> = argv.lines().collect();
 
     let skill_idx = lines
@@ -139,11 +200,12 @@ fn test_pi_wrapper_mounts_skills_dir() {
 /// `--add-dir` and does not sandbox its tools to the working directory.
 #[test]
 fn test_pi_wrapper_announces_artifacts_dir() {
-    let argv = run_pi_wrapper();
-    let lines: Vec<&str> = argv.lines().collect();
+    let h = Harness::new();
+    h.run("pi --model sonnet");
+    let argv = h.read_probe("pi-argv");
 
     assert!(
-        lines.contains(&"--append-system-prompt"),
+        argv.lines().any(|l| l == "--append-system-prompt"),
         "artifacts dir was not announced: {argv}"
     );
     assert!(
@@ -159,7 +221,192 @@ fn test_pi_wrapper_announces_artifacts_dir() {
 /// User arguments are forwarded after the injected flags.
 #[test]
 fn test_pi_wrapper_forwards_user_args() {
-    let argv = run_pi_wrapper();
+    let h = Harness::new();
+    h.run("pi --model sonnet");
+    let argv = h.read_probe("pi-argv");
     let lines: Vec<&str> = argv.lines().collect();
     assert_eq!(&lines[lines.len() - 2..], &["--model", "sonnet"]);
+}
+
+// --- Claude wrapper ---
+
+/// Claude gets the staging dir mounted *and* the artifacts dir named, because
+/// the mounted dir is ephemeral and the symlink inside it is easy to miss.
+#[test]
+fn test_claude_wrapper_mounts_and_announces() {
+    let h = Harness::new();
+    h.run("claude");
+    let argv = h.read_probe("claude-argv");
+    let lines: Vec<&str> = argv.lines().collect();
+
+    let add_idx = lines
+        .iter()
+        .position(|l| *l == "--add-dir")
+        .expect("--add-dir not passed to claude");
+    assert!(
+        lines[add_idx + 1].contains("/cache/akm/myrepo-"),
+        "unexpected --add-dir value: {}",
+        lines[add_idx + 1]
+    );
+
+    assert!(
+        lines.contains(&"--append-system-prompt"),
+        "artifacts dir was not announced: {argv}"
+    );
+    assert!(
+        argv.contains("/artifacts/myrepo"),
+        "append prompt missing the artifacts path: {argv}"
+    );
+    assert!(
+        argv.contains("Never write into the AKM session staging directory"),
+        "append prompt missing the staging warning: {argv}"
+    );
+}
+
+/// The staging root is read-only during the session, so an agent that writes
+/// there gets an error it can act on rather than silent loss at session end.
+#[test]
+fn test_staging_root_rejects_stray_writes() {
+    let h = Harness::new();
+    h.run("claude");
+
+    let stray = h.read_probe("stray-write");
+    assert!(
+        !stray.contains("STRAY WRITE SUCCEEDED"),
+        "staging root accepted a stray write: {stray}"
+    );
+    assert!(
+        stray.contains("Permission denied"),
+        "expected EACCES naming the path, got: {stray}"
+    );
+}
+
+/// The signpost is readable from the mounted dir, for tools with no
+/// `--append-system-prompt` to receive the announcement through.
+#[test]
+fn test_staging_readme_points_at_artifacts_dir() {
+    let h = Harness::new();
+    h.run("claude");
+
+    let readme = h.read_probe("readme");
+    assert!(
+        readme.contains("EPHEMERAL"),
+        "README missing the ephemeral warning: {readme}"
+    );
+    assert!(
+        readme.contains("/artifacts/myrepo"),
+        "README missing the artifacts path: {readme}"
+    );
+
+    let listing = h.read_probe("staging-ls");
+    assert!(
+        listing.contains("README.md") && listing.contains("artifacts"),
+        "staging root should expose both signposts: {listing}"
+    );
+}
+
+// --- Session teardown ---
+
+/// A session that wrote nothing of its own leaves nothing behind.
+#[test]
+fn test_session_end_removes_clean_staging_dir() {
+    let h = Harness::new();
+    let out = h.run(
+        r#"_akm_session_start
+echo "$AKM_SESSION" > "$HOME/session-path"
+_akm_session_end"#,
+    );
+
+    let staging = h.read_probe("session-path").trim().to_string();
+    assert!(!staging.is_empty(), "session start produced no staging dir");
+    assert!(
+        !Path::new(&staging).exists(),
+        "clean staging dir survived teardown: {staging}"
+    );
+    assert!(
+        !h.artifact_dir().join("orphaned").exists(),
+        "clean teardown should not quarantine anything: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A stray file is moved into the artifacts dir instead of being deleted, and
+/// the rescue is reported. This is the data-loss path from issue #23.
+#[test]
+fn test_session_end_quarantines_stray_files() {
+    let h = Harness::new();
+    let out = h.run(
+        r#"_akm_session_start
+echo "$AKM_SESSION" > "$HOME/session-path"
+# Simulate an agent that got past the read-only root — a stale shell init, a
+# chmod, or a tool writing before the seal.
+chmod u+w "$AKM_SESSION"
+mkdir -p "$AKM_SESSION/research"
+echo "700 lines of research" > "$AKM_SESSION/research/findings.md"
+_akm_session_end"#,
+    );
+
+    let staging = h.read_probe("session-path").trim().to_string();
+    let session_id = Path::new(&staging).file_name().unwrap();
+    let rescued = h
+        .artifact_dir()
+        .join("orphaned")
+        .join(session_id)
+        .join("research")
+        .join("findings.md");
+
+    assert!(
+        rescued.exists(),
+        "stray file was not rescued to {}",
+        rescued.display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&rescued).unwrap().trim(),
+        "700 lines of research"
+    );
+    assert!(
+        !Path::new(&staging).exists(),
+        "staging dir should be gone once emptied: {staging}"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("rescued stray session files"),
+        "rescue was not reported: {stderr}"
+    );
+}
+
+/// The next session tells its agent about anything awaiting triage, since the
+/// agent that wrote the files is gone by the time they are rescued.
+#[test]
+fn test_next_session_announces_rescued_files() {
+    let h = Harness::new();
+    let rescued = h.artifact_dir().join("orphaned").join("myrepo-1-2");
+    std::fs::create_dir_all(&rescued).unwrap();
+    std::fs::write(rescued.join("notes.md"), "rescued").unwrap();
+
+    h.run("claude");
+    let argv = h.read_probe("claude-argv");
+
+    assert!(
+        argv.contains("Rescued files awaiting triage"),
+        "orphaned files were not announced: {argv}"
+    );
+    assert!(
+        argv.contains("/artifacts/myrepo/orphaned"),
+        "announcement missing the orphaned path: {argv}"
+    );
+}
+
+/// No rescued files, no notice — the announcement stays quiet in the normal case.
+#[test]
+fn test_no_orphan_notice_when_nothing_rescued() {
+    let h = Harness::new();
+    h.run("claude");
+    let argv = h.read_probe("claude-argv");
+
+    assert!(
+        !argv.contains("Rescued files awaiting triage"),
+        "orphan notice appeared with nothing rescued: {argv}"
+    );
 }

--- a/tests/snapshots/shell_test__shell_init.snap
+++ b/tests/snapshots/shell_test__shell_init.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/shell_test.rs
+assertion_line: 32
 expression: "akm::shell::shell_init_content()"
 ---
 #!/bin/bash
@@ -85,10 +86,81 @@ _akm_skills_session_start() {
 }
 
 _akm_skills_session_end() {
-  if [[ -n "${AKM_SESSION:-}" && -d "$AKM_SESSION" ]]; then
-    rm -rf "$AKM_SESSION"
+  if [[ -z "${AKM_SESSION:-}" || ! -d "$AKM_SESSION" ]]; then
+    unset AKM_SESSION
+    return 0
   fi
+
+  # The root was sealed in _akm_session_start — reopen it so its entries can go.
+  chmod u+w "$AKM_SESSION" 2>/dev/null || true
+
+  # Remove only what session start created. Anything else is a stray write and
+  # has to survive, so the parent goes with rmdir rather than rm -rf.
+  rm -f "$AKM_SESSION/artifacts" "$AKM_SESSION/README.md"
+  local tool_dir
+  for tool_dir in .claude .copilot .agents .pi; do
+    rm -rf "${AKM_SESSION:?}/$tool_dir"
+  done
+
+  if ! rmdir "$AKM_SESSION" 2>/dev/null; then
+    _akm_quarantine_staging
+  fi
+
   unset AKM_SESSION
+}
+
+# Rescue stray files from a staging dir instead of deleting them.
+#
+# Only reached when rmdir found something session start did not create. With
+# artifacts enabled the files move into the artifacts dir, which is git-synced,
+# so _akm_session_end commits them on the way out. Without it there is no
+# durable location, so the staging dir is left on disk rather than removed.
+_akm_quarantine_staging() {
+  if [[ -z "${_AKM_ARTIFACT_DIR:-}" ]]; then
+    echo "akm: kept $AKM_SESSION — it holds files akm did not create" >&2
+    return 0
+  fi
+
+  local dest="$_AKM_ARTIFACT_DIR/orphaned/$(basename "$AKM_SESSION")"
+  if ! mkdir -p "$dest" 2>/dev/null; then
+    echo "akm: kept $AKM_SESSION — could not create $dest" >&2
+    return 0
+  fi
+
+  # -mindepth 1 also catches dotfiles, which a bare glob would miss.
+  find "$AKM_SESSION" -mindepth 1 -maxdepth 1 -exec mv {} "$dest/" \; 2>/dev/null
+
+  # rmdir is the real test: find's exit code says nothing about whether the
+  # individual mv calls succeeded.
+  if rmdir "$AKM_SESSION" 2>/dev/null; then
+    echo "akm: rescued stray session files -> $dest" >&2
+  else
+    echo "akm: kept $AKM_SESSION — could not rescue all of its files" >&2
+  fi
+}
+
+# Signpost for an agent that lists the staging root looking for somewhere to
+# write. Tools that take a system prompt are told the same thing directly (see
+# _akm_artifacts_prompt); this covers the ones that do not.
+_akm_write_staging_readme() {
+  local staging="$1"
+  local artifact_dir="$2"
+
+  {
+    echo "# AKM session staging — EPHEMERAL"
+    echo
+    echo "This directory is deleted when the shell session ends, and its root is"
+    echo "read-only. Do not write here."
+    if [[ -n "$artifact_dir" ]]; then
+      echo
+      echo "Durable outputs — plans/, research/, sessions/, prompts/, archive/ —"
+      echo "belong in the artifacts directory:"
+      echo
+      echo "    $artifact_dir"
+      echo
+      echo "reachable from this directory as ./artifacts/"
+    fi
+  } >"$staging/README.md" 2>/dev/null || true
 }
 
 # --- Artifacts lifecycle ---
@@ -175,6 +247,17 @@ _akm_session_start() {
     done
   fi
 
+  # Seal the staging root. Tools are handed this directory as a working
+  # directory, and the tree is removed on session end — so a stray write here
+  # is silent data loss. Denying writes at the root turns that into an
+  # immediate EACCES the agent sees as a tool error and can act on. Only the
+  # root is sealed; the tool subdirs stay writable for tools that keep state
+  # in them (opencode's OPENCODE_CONFIG_DIR points at one).
+  if [[ -n "$staging_dir" ]]; then
+    _akm_write_staging_readme "$staging_dir" "$artifact_dir"
+    chmod a-w "$staging_dir" 2>/dev/null || true
+  fi
+
   # Export for use in _akm_session_end and _akm_wrap_tool
   export _AKM_ARTIFACT_DIR="${artifact_dir}"
   export _AKM_STAGING_DIR="${staging_dir}"
@@ -219,8 +302,13 @@ _akm_pi_append_file() {
   fi
 }
 
-# The artifacts announcement appended to Pi's system prompt.
-_akm_pi_artifacts_prompt() {
+# --- System prompt announcement ---
+
+# The artifacts announcement, appended to the system prompt of tools that
+# accept one (claude, pi). Naming the resolved absolute path is what makes the
+# durable location unambiguous — an agent given only the staging dir has to
+# infer where artifacts go, and inferring wrong used to cost it its output.
+_akm_artifacts_prompt() {
   cat <<EOF
 ## AKM artifacts directory
 
@@ -230,6 +318,31 @@ That absolute path is this project's AKM artifacts directory. It lives outside
 the repository and holds non-code outputs: plans/, research/, sessions/,
 prompts/, archive/. Write plans, research and session notes there rather than
 into the repository, and read from it with absolute paths.
+
+Never write into the AKM session staging directory — the ephemeral path some
+tools receive as an additional working directory. It is deleted when the shell
+session ends, and its root is read-only to enforce that.
+EOF
+  _akm_orphaned_notice
+}
+
+# Tell the agent about files rescued from an earlier session's staging dir.
+#
+# The rescue happens at session end, when the agent that wrote them is already
+# gone — so the next one is the first that can act on it.
+_akm_orphaned_notice() {
+  local orphaned="$_AKM_ARTIFACT_DIR/orphaned"
+  [[ -d "$orphaned" && -n "$(ls -A "$orphaned" 2>/dev/null)" ]] || return 0
+
+  cat <<EOF
+
+### Rescued files awaiting triage
+
+$orphaned
+
+An earlier session wrote files into its staging directory, which is ephemeral.
+They were moved here rather than deleted. Review them, file them properly under
+the artifacts directory, and remove the rescued copies once done.
 EOF
 }
 
@@ -261,13 +374,28 @@ _akm_wrap_tool() {
         local pi_append
         pi_append="$(_akm_pi_append_file)"
         [[ -n "$pi_append" ]] && cmd+=(--append-system-prompt "$pi_append")
-        cmd+=(--append-system-prompt "$(_akm_pi_artifacts_prompt)")
+        cmd+=(--append-system-prompt "$(_akm_artifacts_prompt)")
+      fi
+      ;;
+    claude)
+      # Claude Code takes both flags: --add-dir mounts the staging tree, and
+      # the appended prompt names the artifacts dir by absolute path. The
+      # symlink alone is not enough — it makes the durable path reachable, not
+      # obvious, and the staging root it sits in is ephemeral.
+      if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
+        cmd+=(--add-dir "$_AKM_STAGING_DIR")
+      elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
+        cmd+=(--add-dir "$_AKM_ARTIFACT_DIR")
+      fi
+      if [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then
+        cmd+=(--append-system-prompt "$(_akm_artifacts_prompt)")
       fi
       ;;
     *)
-      # claude and copilot support --add-dir. Artifacts are symlinked into the
-      # staging dir, so one dir is enough; with artifacts but no staging dir,
-      # pass the artifact dir directly.
+      # copilot supports --add-dir but has no --append-system-prompt, so it
+      # relies on the staging README and the read-only root instead. Artifacts
+      # are symlinked into the staging dir, so one dir is enough; with
+      # artifacts but no staging dir, pass the artifact dir directly.
       if [[ -n "${_AKM_STAGING_DIR:-}" ]]; then
         cmd+=(--add-dir "$_AKM_STAGING_DIR")
       elif [[ -n "${_AKM_ARTIFACT_DIR:-}" ]]; then


### PR DESCRIPTION
Fixes #23.

## The finding that changed the fix

The issue proposes fixing `global-instructions.md` first. That can't land here — akm creates that file **empty** (`setup.rs:289`) or with a bare `# Global LLM Instructions` header (`edit.rs:32`) and never writes the offending prose. It's user content.

Two other things turned out differently than the report assumed:

**The artifacts symlink was never the problem.** `rm -rf` unlinks a symlink rather than traversing it — verified. Writes *through* `<staging>/artifacts` were always safe, which is why re-writing the same files to `~/.akm/artifacts/groupeR/` synced fine.

**At the time of the loss there was no root-level symlink to write through.** The reporter's installed `akm-init.sh` was dated Mar 12 and only created *per-tool* symlinks. The root-level `ln -sfn "$artifact_dir" "$staging_dir/artifacts"` exists only at HEAD. So the agent got `--add-dir <staging>`, looked inside, saw three dotdirs and nothing resembling `plans/ research/ sessions/`, and did the only self-consistent thing: `mkdir -p <staging>/research`. A real directory, bypassing every symlink.

And HEAD only half-closes it: the instructions say the add-dir root **is** the artifacts folder, so an agent still writes `<staging>/research/` rather than `<staging>/artifacts/research/`. The nesting is one level off from what the prose describes.

So the symlink makes the durable path *reachable*, never *unmistakable* — and doesn't make guessing wrong survivable.

## Four layers

| | Layer | Mechanism | Covers |
|---|---|---|---|
| 1 | **Named** | `--append-system-prompt` with the resolved absolute path + an explicit "never write to staging" | `claude`, `pi` |
| 2 | **Signposted** | `README.md` at the staging root saying the same | `copilot`, `opencode` |
| 3 | **Sealed** | staging root `chmod a-w` | all |
| 4 | **Rescued** | targeted delete + `rmdir`, strays quarantined | all |

`_akm_pi_artifacts_prompt` becomes the shared `_akm_artifacts_prompt`; `claude` gets its own `case` branch so `*)` is now copilot-only.

**Layer 3 is the one that does the work.** A stray write now fails at the moment it happens:

```
mkdir: cannot create directory '<staging>/research': Permission denied
```

The agent sees that as a tool error, in context, and can correct — in every harness, with no daemon. Only the root is sealed; tool subdirs stay writable (opencode's `OPENCODE_CONFIG_DIR` points at one).

**Layer 4 turns silent loss into recoverable loss.** Teardown removes only the dirs it created, then `rmdir`s the parent — which fails harmlessly if anything unexpected is inside. Leftovers move to `<artifacts>/<repo>/orphaned/<session_id>/`, which is git-synced, so `_akm_artifacts_commit_and_push` commits them on the way out. The next session's system prompt then tells its agent to triage them: the rescue happens at session end, when the agent that wrote the files is already gone, so the *next* one is the first that can act.

### On the watcher idea

Considered and rejected — there's no delivery channel. Nothing outside a live agent can reach its context: terminal output isn't something the model sees, only tool results are. `inotify` would also breach the no-runtime-dependencies rule (criterion 9). Harness hooks are the one real in-band channel, but they're claude-only out of four harnesses and would mean akm managing `settings.json`. The filesystem's own EACCES is the only write-time signal that is in-band, immediate and harness-agnostic — which is layer 3.

### Option (d) dropped

The same-shell restart guard existed to tame the confusing mid-session path rotation. With staging sealed and holding nothing but symlinks, rotation destroys nothing, so there's nothing left to migrate — and reusing a dir across sessions would break the clean-slate guarantee staging exists to provide.

## The delivery gap (why this bit in the first place)

`install_shell_init` was called **only** from `akm setup` — `akm update` swapped the binary and left the script alone. That's how a March shell init ended up running under a 1.0.0-rc1 binary, and it would have swallowed this fix too.

Since `akm-init.sh` is `include_str!`'d at compile time, the running process holds the *stale* copy and cannot refresh it. So `download_and_replace` invokes the **new** binary via a hidden `shell-install` command to write its own. Non-fatal — the swap already succeeded, so a failure warns and points at `akm setup`.

`src/shell/mod.rs:36` already claimed "picks up new version on update"; that intent was never wired up.

## Tests

`tests/shell_test.rs` grows a `Harness` that sources the init with stubbed tools. The `claude` stub probes the dir it's handed, so one run asserts layers 1–3 together.

- `test_claude_wrapper_mounts_and_announces` — both flags, path + warning present
- `test_staging_root_rejects_stray_writes` — EACCES, no successful write
- `test_staging_readme_points_at_artifacts_dir` — signpost readable, both signposts listed
- `test_session_end_removes_clean_staging_dir` — no leak, no spurious quarantine
- `test_session_end_quarantines_stray_files` — replays #23: content survives, staging gone, rescue reported
- `test_next_session_announces_rescued_files` / `test_no_orphan_notice_when_nothing_rescued`

Existing pi tests preserved. 12/12 in `shell_test`, **236 across the suite**, clippy `-D warnings` clean, fmt clean.

Also verified end-to-end against the real binary (tests stub `akm`, so this is a distinct path): read-only root confirmed `dr-xr-xr-x`, the issue's exact `mkdir` blocked, writes through the symlink still landing in the durable dir, clean teardown leaving nothing, and a stray file surviving into `orphaned/` and being announced to the next session.

## Note for maintainers

`_akm_skills_session_end` introduces a **second** harness-coupled tool-dir loop. A harness added to `_akm_skills_session_start` but missed there gets left behind and quarantined as a stray on *every* session. `AGENTS.md` item 2 updated to say so.

## After merging

`akm update` won't carry this to an already-installed akm — the fix to `akm update` is itself in the new binary. Run `akm setup` once, then restart your shell. Subsequent updates refresh the script automatically.