### PR TITLE
feat: offer publish after promote and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ akm skills import https://github.com/user/repo/tree/main/skills/my-skill --force
 
 Both `/tree/` (directory) and `/blob/` (file) GitHub URLs are supported. For private repos, set the `GITHUB_TOKEN` environment variable.
 
+#### Publishing after promote or import
+
+When run interactively, `promote` and `import` end by offering to publish the
+skill to your personal registry:
+
+```
+Publish to personal registry? [y/N]:
+```
+
+The prompt is skipped when `skills.personal_registry` is unset or when stdin is
+not a terminal. The description and tags you entered at the metadata prompts are
+carried into the registry. If publishing fails, the skill still stays in cold
+storage — retry with `akm skills publish <id>`.
+
 ### Artifacts
 
 ```bash

--- a/src/commands/skills/import.rs
+++ b/src/commands/skills/import.rs
@@ -5,6 +5,7 @@
 //! runs interactive prompts, and copies to cold storage.
 
 use crate::commands::skills::promote::copy_dir_recursive;
+use crate::config::Config;
 use crate::error::{Error, IoContext, Result};
 use crate::github::{self, GitHubHttpClient};
 use crate::library::frontmatter::Frontmatter;
@@ -19,12 +20,14 @@ use std::io::{self, BufRead, IsTerminal, Write};
 ///
 /// # Arguments
 /// * `paths` — Resolved XDG paths
+/// * `config` — Loaded config, for the optional publish prompt
 /// * `url` — GitHub URL to a directory containing SKILL.md
 /// * `force` — Skip overwrite confirmation
 /// * `custom_id` — Optional override for the skill ID
 /// * `tool_dirs` — Tool directories for symlink rebuild
 pub fn run(
     paths: &Paths,
+    config: &Config,
     url: &str,
     force: bool,
     custom_id: Option<&str>,
@@ -166,6 +169,9 @@ pub fn run(
     println!("  {count} core symlinks rebuilt");
     println!();
     println!("Imported skill '{id}' from GitHub");
+
+    // Step 10: Offer to publish to the personal registry
+    super::publish::offer(paths, config, &id);
 
     Ok(())
 }

--- a/src/commands/skills/promote.rs
+++ b/src/commands/skills/promote.rs
@@ -2,6 +2,7 @@
 //!
 //! Only skills (directories with SKILL.md) can be promoted, not agents.
 
+use crate::config::Config;
 use crate::error::{Error, IoContext, Result};
 use crate::library::frontmatter::Frontmatter;
 use crate::library::libgen;
@@ -16,10 +17,17 @@ use std::path::{Path, PathBuf};
 ///
 /// # Arguments
 /// * `paths` — Resolved XDG paths
+/// * `config` — Loaded config, for the optional publish prompt
 /// * `spec_path` — Path to directory containing SKILL.md
 /// * `force` — Skip overwrite confirmation
 /// * `tool_dirs` — Tool directories for symlink rebuild
-pub fn run(paths: &Paths, spec_path: &str, force: bool, tool_dirs: &ToolDirs) -> Result<()> {
+pub fn run(
+    paths: &Paths,
+    config: &Config,
+    spec_path: &str,
+    force: bool,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
     // Step 1: Resolve and validate path
     let spec_path = PathBuf::from(spec_path);
     let spec_path = if spec_path.is_absolute() {
@@ -142,6 +150,9 @@ pub fn run(paths: &Paths, spec_path: &str, force: bool, tool_dirs: &ToolDirs) ->
     println!("  {count} core symlinks rebuilt");
     println!();
     println!("Promoted skill '{id}' to cold storage");
+
+    // Step 9: Offer to publish to the personal registry
+    super::publish::offer(paths, config, &id);
 
     Ok(())
 }

--- a/src/commands/skills/publish.rs
+++ b/src/commands/skills/publish.rs
@@ -6,11 +6,12 @@ use crate::config::Config;
 use crate::error::{Error, IoContext, Result};
 use crate::git::Git;
 use crate::library::libgen;
-use crate::library::spec::SpecType;
+use crate::library::spec::{Spec, SpecType};
 use crate::library::Library;
 use crate::paths::Paths;
 use crate::registry::git::GitRegistry;
 use crate::registry::RegistrySource;
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::Path;
 
 /// Run the `akm skills publish` command.
@@ -69,8 +70,9 @@ pub fn run(paths: &Paths, config: &Config, id: &str, dry_run: bool) -> Result<()
     copy_spec_to_registry(spec, &source_path, cache_dir)?;
     println!("  Copied {} to personal registry", spec.spec_type);
 
-    // Step 5: Regenerate library.json in cache
+    // Step 5: Regenerate library.json in cache, then carry local metadata over
     libgen::generate(cache_dir)?;
+    apply_local_metadata(cache_dir, spec)?;
 
     // Step 6: Dry run — show diff, reset
     if dry_run {
@@ -106,6 +108,59 @@ pub fn run(paths: &Paths, config: &Config, id: &str, dry_run: bool) -> Result<()
     Ok(())
 }
 
+/// Offer to publish `id` to the personal registry, after a promote or import.
+///
+/// Silently does nothing unless stdin is a TTY and a personal registry is
+/// configured. A failed publish is reported as a warning: the caller's work is
+/// already committed to cold storage, so it must not fail the whole command.
+pub(crate) fn offer(paths: &Paths, config: &Config, id: &str) {
+    if !io::stdin().is_terminal() {
+        return;
+    }
+
+    let configured = config
+        .skills
+        .personal_registry
+        .as_deref()
+        .is_some_and(|url| !url.is_empty());
+    if !configured {
+        return;
+    }
+
+    println!();
+    print!("Publish to personal registry? [y/N]: ");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    if !input.trim().eq_ignore_ascii_case("y") {
+        return;
+    }
+
+    println!();
+    if let Err(e) = run(paths, config, id, false) {
+        eprintln!("Warning: publish failed: {e}");
+        eprintln!("Retry with: akm skills publish {id}");
+    }
+}
+
+/// Copy user-edited metadata onto the registry's `library.json` entry.
+///
+/// `libgen` derives entries for specs the registry has not seen from SKILL.md
+/// frontmatter, so the description and tags set locally (via promote, import or
+/// edit) would otherwise never be published. `core` is deliberately excluded —
+/// sync treats it as a per-user override rather than a property of the spec.
+fn apply_local_metadata(cache_dir: &Path, spec: &Spec) -> Result<()> {
+    let library_path = cache_dir.join("library.json");
+    let mut library = Library::load_from(&library_path)?;
+
+    if let Some(entry) = library.get_mut(&spec.id) {
+        entry.description = spec.description.clone();
+        entry.tags = spec.tags.clone();
+    }
+
+    library.save_to(&library_path)
+}
+
 /// Copy a spec from cold storage into the registry cache directory.
 fn copy_spec_to_registry(
     spec: &crate::library::spec::Spec,
@@ -135,4 +190,87 @@ fn copy_spec_to_registry(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a registry cache holding one skill, with library.json generated
+    /// by libgen (i.e. metadata derived from frontmatter).
+    fn cache_with_generated_library(dir: &Path) {
+        let skill_dir = dir.join("skills").join("test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Test Skill\ndescription: Frontmatter description\n---\nContent",
+        )
+        .unwrap();
+        libgen::generate(dir).unwrap();
+    }
+
+    fn local_spec() -> Spec {
+        let mut spec = Spec::new(
+            "test-skill".to_string(),
+            SpecType::Skill,
+            "Test Skill".to_string(),
+            "Edited description".to_string(),
+        );
+        spec.tags = vec!["testing".to_string(), "rust".to_string()];
+        spec.core = true;
+        spec
+    }
+
+    /// The description and tags a user typed at the promote/import prompts must
+    /// reach the registry, not the frontmatter values libgen derives.
+    #[test]
+    fn local_description_and_tags_are_published() {
+        let tmp = TempDir::new().unwrap();
+        cache_with_generated_library(tmp.path());
+
+        let library = Library::load_from(&tmp.path().join("library.json")).unwrap();
+        assert_eq!(
+            library.get("test-skill").unwrap().description,
+            "Frontmatter description"
+        );
+
+        apply_local_metadata(tmp.path(), &local_spec()).unwrap();
+
+        let library = Library::load_from(&tmp.path().join("library.json")).unwrap();
+        let entry = library.get("test-skill").unwrap();
+        assert_eq!(entry.description, "Edited description");
+        assert_eq!(entry.tags, vec!["testing", "rust"]);
+    }
+
+    /// `core` is a per-user preference that sync preserves as a local override,
+    /// so publishing must not push it onto every consumer of the registry.
+    #[test]
+    fn core_flag_is_not_published() {
+        let tmp = TempDir::new().unwrap();
+        cache_with_generated_library(tmp.path());
+
+        apply_local_metadata(tmp.path(), &local_spec()).unwrap();
+
+        let library = Library::load_from(&tmp.path().join("library.json")).unwrap();
+        assert!(!library.get("test-skill").unwrap().core);
+    }
+
+    /// A spec absent from the registry cache must not create a phantom entry.
+    #[test]
+    fn unknown_spec_leaves_library_untouched() {
+        let tmp = TempDir::new().unwrap();
+        cache_with_generated_library(tmp.path());
+
+        let mut spec = local_spec();
+        spec.id = "not-in-registry".to_string();
+        apply_local_metadata(tmp.path(), &spec).unwrap();
+
+        let library = Library::load_from(&tmp.path().join("library.json")).unwrap();
+        assert!(library.get("not-in-registry").is_none());
+        assert_eq!(
+            library.get("test-skill").unwrap().description,
+            "Frontmatter description"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,10 +338,19 @@ fn main() -> ExitCode {
                     commands::skills::clean::run(&paths, &tool_dirs, project, dry_run)
                 }
                 Some(SkillsCommands::Promote { path, force }) => {
-                    commands::skills::promote::run(&paths, &path, force, &tool_dirs)
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
+                    commands::skills::promote::run(&paths, &config, &path, force, &tool_dirs)
                 }
                 Some(SkillsCommands::Import { url, force, id }) => {
-                    commands::skills::import::run(&paths, &url, force, id.as_deref(), &tool_dirs)
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
+                    commands::skills::import::run(
+                        &paths,
+                        &config,
+                        &url,
+                        force,
+                        id.as_deref(),
+                        &tool_dirs,
+                    )
                 }
                 Some(SkillsCommands::Edit { id }) => {
                     commands::skills::edit::run(&paths, &id, &tool_dirs)

--- a/tests/skills_commands_test.rs
+++ b/tests/skills_commands_test.rs
@@ -3,6 +3,7 @@
 //! Tests use temp directories and mock library data to exercise
 //! add, remove, list, search, status, load, unload, loaded, clean, promote.
 
+use akm::config::Config;
 use akm::error::Error;
 use akm::library::spec::{Spec, SpecType};
 use akm::library::tool_dirs::ToolDirs;
@@ -413,8 +414,13 @@ fn promote_requires_skill_md() {
     let skill_dir = tmp.path().join("no-skill-md");
     std::fs::create_dir_all(&skill_dir).unwrap();
 
-    let result =
-        akm::commands::skills::promote::run(&paths, &skill_dir.to_string_lossy(), true, &tool_dirs);
+    let result = akm::commands::skills::promote::run(
+        &paths,
+        &Config::default(),
+        &skill_dir.to_string_lossy(),
+        true,
+        &tool_dirs,
+    );
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(matches!(err, Error::NoSkillMd { .. }));
@@ -426,8 +432,13 @@ fn promote_nonexistent_dir() {
     let paths = test_paths(&tmp);
     let tool_dirs = test_tool_dirs(&tmp);
 
-    let result =
-        akm::commands::skills::promote::run(&paths, "/nonexistent/path/xyz", true, &tool_dirs);
+    let result = akm::commands::skills::promote::run(
+        &paths,
+        &Config::default(),
+        "/nonexistent/path/xyz",
+        true,
+        &tool_dirs,
+    );
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(matches!(err, Error::PromoteDirNotFound { .. }));
@@ -447,8 +458,13 @@ fn promote_requires_name_in_frontmatter() {
     )
     .unwrap();
 
-    let result =
-        akm::commands::skills::promote::run(&paths, &skill_dir.to_string_lossy(), true, &tool_dirs);
+    let result = akm::commands::skills::promote::run(
+        &paths,
+        &Config::default(),
+        &skill_dir.to_string_lossy(),
+        true,
+        &tool_dirs,
+    );
     assert!(result.is_err());
 }
 
@@ -483,6 +499,47 @@ fn promote_new_skill_via_cmd() {
     assert!(paths.data_dir().join("skills").join("local-skill").is_dir());
     let lib = Library::load(&paths).unwrap();
     assert!(lib.contains("local-skill"));
+}
+
+/// The publish prompt is TTY-gated. Under a piped stdin it must not appear —
+/// and must not attempt a network publish — even with a registry configured.
+#[test]
+fn promote_does_not_prompt_to_publish_non_tty() {
+    use assert_cmd::cargo::cargo_bin_cmd;
+
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+
+    std::fs::create_dir_all(paths.data_dir().join("skills")).unwrap();
+    Library::new().save(&paths).unwrap();
+
+    let config_dir = tmp.path().join("config").join("akm");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        "[skills]\npersonal_registry = \"https://example.invalid/repo.git\"\n",
+    )
+    .unwrap();
+
+    let skill_dir = tmp.path().join("local-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: Local Skill\ndescription: A test skill\n---\nContent",
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("akm")
+        .args(["skills", "promote", &skill_dir.to_string_lossy(), "--force"])
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_CACHE_HOME", tmp.path().join("cache"))
+        .env("HOME", tmp.path().join("home"))
+        .assert()
+        .success()
+        .stdout(predicates::prelude::PredicateBooleanExt::not(
+            pred_contains("Publish to personal registry?"),
+        ));
 }
 
 #[test]


### PR DESCRIPTION
Closes #18.

Interactive `akm skills promote` and `akm skills import` now end by offering to publish the skill to the personal registry.

```
Promoted skill 'my-skill' to cold storage

Publish to personal registry? [y/N]:
```

## Decisions

| Case | Behaviour |
|---|---|
| `skills.personal_registry` unset/empty | Prompt skipped silently |
| Non-TTY stdin | Prompt skipped — output and exit code unchanged |
| Publish fails | Warning + `Retry with: akm skills publish <id>`, exit 0 |
| Default (bare Enter) | No — matches surrounding prompts, and publishing pushes to a remote |

No new flags. `akm skills publish <id>` already covers the scriptable path, so `--publish` would be redundant surface.

**Exit code on failure** is the notable one. By the time the prompt appears, promote/import has already succeeded: the skill is in cold storage, `library.json` is regenerated, symlinks are rebuilt. Propagating a publish error would make `akm skills import` report failure for durable, completed work — over network conditions unrelated to the import. This mirrors how `publish.rs` already degrades a failed registry pull into a warning.

## Also fixes: publish dropped user-edited metadata

Pre-existing bug, surfaced by this feature. `publish` copies spec files into the registry cache and then calls `libgen::generate`, which derives entries for specs the registry hasn't seen from **SKILL.md frontmatter** — it never reads the local `library.json`. So the description and tags typed at the promote/import prompts never left the machine: tags were dropped, description reverted to the frontmatter value.

That matters because the registry's `library.json` is the source of truth `sync` pulls down into cold storage, and `search` matches against `tags`.

Wiring a publish prompt directly after the metadata prompts, where saying yes silently discards those edits, would have shipped a confusing feature. `publish` now copies the local description and tags onto the registry entry.

`core` is deliberately excluded — `sync` treats it as a per-user local override, so publishing it would push one user's "always installed globally" preference onto every consumer of the registry.

## Tests

- 3 unit tests in `publish.rs` for the metadata carry-over: description/tags published, `core` not published, unknown spec creates no phantom entry.
- Integration test asserting the prompt does not appear under piped stdin *with a registry configured* — guards the TTY gate, whose regression would mean an unattended network publish.
- Existing `promote`/`import` call sites updated for the new `&Config` parameter.

`cargo test` (20 suites), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt` all clean.