### PR TITLE
chore(release): 1.0.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 1.0.0-rc2
+
+- Fix the session staging directory silently eating agent output
+  - Agents told to write to "the additional working directory" wrote into the
+    staging dir, which is `rm -rf`'d on session end — the files were lost
+  - The artifacts directory is now named by resolved absolute path in the
+    system prompt (claude and pi), signposted by a `README.md` at the staging
+    root for harnesses with no system-prompt flag, and the staging root is
+    made read-only so a stray write fails loudly instead of vanishing later
+  - Teardown now removes only the directories it created and rescues anything
+    left to `<artifacts>/<repo>/orphaned/<session>/` for the next session to triage
+  - `akm update` now rewrites `akm-init.sh` as well as the binary — previously
+    an updated binary kept running a months-old shell init
+- Offer to publish to the personal registry after an interactive `skills promote`
+  or `skills import`
+  - Skipped when no personal registry is configured or stdin is not a TTY, so
+    non-interactive output and exit codes are unchanged
+  - Fix `skills publish` dropping the description and tags entered at the
+    promote/import prompts, which left the registry — the source of truth for
+    sync and search — carrying the values derived from `SKILL.md` frontmatter
+- Make the interactive skills list modal so actions work on a filtered list
+  - Previously typing a filter disabled every action key, and the only way out
+    cleared the filter along with it
+  - `/` starts editing the filter; `Enter` or `Esc` returns to normal mode with
+    the filter still applied, where `c`/`e`/`a`/`r` act on the filtered rows
+  - `Esc` no longer quits either interactive view — only `q` and `Ctrl+C` do
+  - The status dashboard gains `e` (edit) and now matches the list view's keys
+- Prune stale narrative from the docs and split maintainer material out of
+  README and AGENTS.md into `docs/development.md` and `docs/harnesses.md`
+
 # 1.0.0-rc1
 
 - Add Pi (https://pi.dev) as a first-tier harness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akm"
-version = "1.0.0-rc1"
+version = "1.0.0-rc2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akm"
-version = "1.0.0-rc1"
+version = "1.0.0-rc2"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Agent Kit Manager — manage reusable LLM skills, artifacts, and instructions"

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -253,6 +253,10 @@ mod tests {
         assert!(!is_newer("1.0.0-rc1", "1.0.0-alpha.11"));
         assert!(!is_newer("1.0.0-rc1", "1.0.0-rc1"));
         assert!(is_newer("1.0.0-rc1", "1.0.0"));
+        // rc1 → rc2 falls to the lexical branch: neither identifier parses
+        // as a number, because the dot separator is absent.
+        assert!(is_newer("1.0.0-rc1", "1.0.0-rc2"));
+        assert!(!is_newer("1.0.0-rc2", "1.0.0-rc1"));
     }
 
     #[test]

--- a/tests/snapshots/update_test__version_output.snap
+++ b/tests/snapshots/update_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/update_test.rs
 expression: stdout.trim()
 ---
-akm 1.0.0-rc1
+akm 1.0.0-rc2


### PR DESCRIPTION
Release prep for `v1.0.0-rc2`. No behaviour changes of its own — bumps the version, records the changelog, and pins the upgrade path.

## What's in the release

Four PRs since `v1.0.0-rc1`:

| PR | |
|---|---|
| #24 | **fix:** stop the session staging dir from eating agent output (closes #23) |
| #25 | **feat:** offer publish after promote and import (closes #18) |
| #26 | **fix:** modal TUI list view + harmonised status keys (closes #19) |
| #22 | **docs:** prune stale narrative, split maintainer docs out of README/AGENTS.md |

#24 is the reason to ship: agents told to write to "the additional working directory" wrote into the staging dir and lost the files on session end — ~700 lines of research in the reported case. That PR also closes the delivery gap that caused the incident, where `akm update` swapped the binary but left a months-old `akm-init.sh` in place.

## Changes here

- `Cargo.toml` / `Cargo.lock` → `1.0.0-rc2`
- `tests/snapshots/update_test__version_output.snap` regenerated (one line, the version string)
- `CHANGELOG.md` entry for rc2
- Two assertions added to `test_is_newer_alpha_to_rc1` pinning `rc1 → rc2`

## On that last one

`is_newer` is what decides whether shipped rc1 users are offered this release, so the path is worth a test rather than an assumption. `rc1` and `rc2` both spell the pre-release without a dot separator, so neither identifier parses as a number and the comparison falls through to `compare_pre`'s lexical branch. Verified passing, both directions.

## Verification

```
cargo test                                  # 181 passed, 0 failed
cargo clippy --all-targets -- -D warnings   # clean
cargo fmt --check                           # clean
```

Once merged, `v1.0.0-rc2` gets tagged and pushed; the release workflow checks the tag against `Cargo.toml`, builds Linux x86_64 + macOS aarch64, and publishes to crates.io.