### PR TITLE
chore(release): 1.0.0-rc4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akm"
-version = "1.0.0-rc2"
+version = "1.0.0-rc4"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akm"
-version = "1.0.0-rc2"
+version = "1.0.0-rc4"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Agent Kit Manager — manage reusable LLM skills, artifacts, and instructions"

--- a/tests/snapshots/update_test__version_output.snap
+++ b/tests/snapshots/update_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/update_test.rs
 expression: stdout.trim()
 ---
-akm 1.0.0-rc2
+akm 1.0.0-rc4


### PR DESCRIPTION
Bumps `Cargo.toml` to 1.0.0-rc4 (rc3 was never cut; the previous bump was missed, leaving the manifest on rc2), refreshes `Cargo.lock` and the `akm --version` snapshot.

Changelog for rc4 already landed on main via #29.

Merging this, then tagging `v1.0.0-rc4`, triggers the release workflow.