### PR TITLE
feat: batch publishing — one intent is one commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+- Publishing is batched: one intent is one commit
+  - `akm skills core --publish` now promotes *and* pushes, in a single commit,
+    staging only sidecars so an in-flight `SKILL.md` is never swept in
+  - `akm skills publish` with no id publishes every pending spec at once
+  - `--dry-run` on both
+- Fix a commit whose push failed never being retried — publish now pushes
+  commits already on `HEAD` instead of reporting nothing to do
+
 # 1.0.0-rc4
 
 **Breaking: the cold library is wiped and re-cloned on first sync.** The

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ akm skills revert my-skill       # discard local changes (--remote: take the reg
 akm skills core                  # show core flags (--adopt / --publish to reconcile)
 akm skills promote ./my-skill     # import local skill to cold storage
 akm skills import <github-url>   # import skill from a GitHub URL
-akm skills publish my-skill      # publish to personal registry
+akm skills publish my-skill      # publish one spec to personal registry
+akm skills publish               # publish everything pending, in one commit
 akm skills clean --dry-run       # preview stale spec removal
 ```
 
@@ -147,6 +148,11 @@ Not yet published (2):
   Publish with 'akm skills publish <id>'.
 ```
 
+One intent is one commit. `akm skills publish <id>` sends a single spec;
+`akm skills publish` with no id sends everything pending as one commit and one
+push, however many specs that is. Add `--dry-run` to either to see what would
+go without touching the remote.
+
 The same states show as markers in `akm skills list` and `akm skills status`:
 `*` edited here and unpublished, `v` the registry is ahead, `!` both moved.
 
@@ -155,7 +161,9 @@ Each skill carries its human-facing metadata in an `akm.json` sidecar beside its
 `library.json` is a derived index, regenerated on every sync — edit the sidecar
 (or `akm skills edit --meta`), never the index. `core` defaults live in the
 sidecar and propagate; a local `c` toggle in the TUI stays on this machine, and
-`akm skills core --publish` promotes it for every machine.
+`akm skills core --publish` promotes it for every machine — committing and
+pushing every promoted sidecar together, and nothing else, so a `SKILL.md` you
+have open stays behind.
 
 #### Importing skills from GitHub
 

--- a/src/commands/skills/core.rs
+++ b/src/commands/skills/core.rs
@@ -7,15 +7,17 @@
 //!
 //! * `--adopt` throws this machine's deviations away and follows the registry;
 //! * `--publish` promotes them into the sidecars so they become the default
-//!   everywhere, then leaves the specs staged for `akm skills publish`.
+//!   everywhere, and sends them to the registry.
 
-use crate::error::Result;
+use crate::config::Config;
+use crate::error::{Error, Result};
 use crate::library::local::LocalOverrides;
 use crate::library::spec::SpecMeta;
 use crate::library::symlinks;
 use crate::library::tool_dirs::ToolDirs;
 use crate::library::Library;
 use crate::paths::Paths;
+use crate::registry::{PublishOutcome, Registry};
 
 /// Which reconciliation the user asked for, if any.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,8 +31,13 @@ pub enum CoreAction {
 }
 
 /// Run the `akm skills core` command.
-pub fn run(paths: &Paths, action: CoreAction, tool_dirs: &ToolDirs) -> Result<()> {
-    let library_dir = paths.library_dir();
+pub fn run(
+    paths: &Paths,
+    config: &Config,
+    action: CoreAction,
+    tool_dirs: &ToolDirs,
+    dry_run: bool,
+) -> Result<()> {
     let library = Library::load_checked(paths)?;
     let mut overrides = LocalOverrides::load_from(&paths.local_json())?;
 
@@ -39,7 +46,7 @@ pub fn run(paths: &Paths, action: CoreAction, tool_dirs: &ToolDirs) -> Result<()
     match action {
         CoreAction::Show => return show(&library, &overrides),
         CoreAction::Adopt => adopt(paths, &mut overrides, tool_dirs)?,
-        CoreAction::Publish => publish_defaults(&library_dir, &library, &mut overrides)?,
+        CoreAction::Publish => publish_defaults(paths, config, &library, &mut overrides, dry_run)?,
     }
 
     overrides.save_to(&paths.local_json())?;
@@ -108,54 +115,125 @@ fn adopt(paths: &Paths, overrides: &mut LocalOverrides, tool_dirs: &ToolDirs) ->
     Ok(())
 }
 
-/// Write this machine's core choices into the sidecars, ready to publish.
+/// Promote this machine's core choices and send them to the registry.
+///
+/// One intent is one commit: every sidecar goes in a single commit and a
+/// single push. Only sidecar paths are staged, so a `SKILL.md` under edit is
+/// never swept into a metadata change.
 fn publish_defaults(
-    library_dir: &std::path::Path,
+    paths: &Paths,
+    config: &Config,
     library: &Library,
     overrides: &mut LocalOverrides,
+    dry_run: bool,
 ) -> Result<()> {
     if overrides.deviation_count() == 0 {
         println!("No local core overrides to publish.");
         return Ok(());
     }
 
-    let ids: Vec<String> = overrides.core.keys().cloned().collect();
-    let mut promoted = Vec::new();
+    let url = config.registry_url().ok_or(Error::NoPersonalRegistry)?;
+    let library_dir = paths.library_dir();
+    let registry = Registry::new(url, &library_dir);
 
-    for id in ids {
-        let Some(spec) = library.get(&id) else {
-            overrides.clear_core(&id);
+    if !registry.is_cloned() {
+        return Err(Error::RegistrySync {
+            name: "personal".into(),
+            message: "The library is not a registry checkout. Run 'akm skills sync' first.".into(),
+        });
+    }
+
+    // Resolve everything before writing anything, so a dry run and a real run
+    // report the same set.
+    let ids: Vec<String> = overrides.core.keys().cloned().collect();
+    let mut promoted: Vec<String> = Vec::new();
+    let mut pathspecs: Vec<String> = Vec::new();
+    let mut stale: Vec<String> = Vec::new();
+
+    for id in &ids {
+        match library.get(id) {
+            Some(spec) => {
+                promoted.push(id.clone());
+                pathspecs.push(spec.sidecar_pathspec());
+            }
+            // A deviation for a spec that no longer exists is just noise.
+            None => stale.push(id.clone()),
+        }
+    }
+
+    if promoted.is_empty() {
+        println!("No local core overrides to publish.");
+        for id in &stale {
+            overrides.clear_core(id);
+        }
+        return Ok(());
+    }
+
+    let message = commit_message(&promoted);
+
+    if dry_run {
+        println!(
+            "Dry run — would publish {} core setting(s):",
+            promoted.len()
+        );
+        for id in &promoted {
+            println!("  {id}");
+        }
+        println!();
+        println!(
+            "As one commit: {}",
+            message.lines().next().unwrap_or(&message)
+        );
+        println!("To: {}", registry.url());
+        return Ok(());
+    }
+
+    for id in &promoted {
+        let Some(spec) = library.get(id) else {
             continue;
         };
-
-        let sidecar = spec.sidecar_path(library_dir);
+        let sidecar = spec.sidecar_path(&library_dir);
         let mut meta = if sidecar.is_file() {
             SpecMeta::load_from(&sidecar)?
         } else {
             spec.to_meta()
         };
-
         // `library.json` already carries the effective value for this machine,
-        // which is precisely what we are promoting to the default.
+        // which is precisely what is being promoted to the default.
         meta.core = spec.core;
         meta.save_to(&sidecar)?;
-
-        overrides.clear_core(&id);
-        promoted.push(id);
     }
 
-    println!(
-        "Promoted {} core setting(s) to the registry default:",
-        promoted.len()
-    );
-    for id in &promoted {
-        println!("  {id}");
+    match registry.publish(&pathspecs, &message)? {
+        PublishOutcome::NothingToDo => {
+            println!("Core defaults already match the registry.");
+        }
+        PublishOutcome::Published => {
+            println!("Published {} core setting(s):", promoted.len());
+            for id in &promoted {
+                println!("  {id}");
+            }
+            println!();
+            println!("Pushed to {}", registry.url());
+        }
     }
-    println!();
-    println!("Publish them with:");
-    for id in &promoted {
-        println!("  akm skills publish {id}");
+
+    // Only a landed push makes it safe to forget the deviations: clearing them
+    // earlier would leave a failed publish with nothing to retry from.
+    for id in promoted.iter().chain(stale.iter()) {
+        overrides.clear_core(id);
     }
 
     Ok(())
+}
+
+/// One line naming the change, one body line naming the specs.
+///
+/// *update*, not *set*: a deviation can turn `core` off as well as on.
+fn commit_message(ids: &[String]) -> String {
+    format!(
+        "chore(core): update core defaults for {} spec(s)\n\n{}",
+        ids.len(),
+        ids.join(", ")
+    )
 }

--- a/src/commands/skills/publish.rs
+++ b/src/commands/skills/publish.rs
@@ -87,6 +87,86 @@ pub fn run(paths: &Paths, config: &Config, id: &str, dry_run: bool) -> Result<()
     Ok(())
 }
 
+/// Publish every spec holding changes the registry has not seen.
+///
+/// One commit and one push for the whole set: the unit of work is the user's
+/// intent, not the number of specs it happened to touch. Staging is by
+/// explicit spec pathspec, never `-A`, so the derived `library.json` index is
+/// left alone.
+pub fn run_all(paths: &Paths, config: &Config, dry_run: bool) -> Result<()> {
+    let url = config.registry_url().ok_or(Error::NoPersonalRegistry)?;
+    let library_dir = paths.library_dir();
+    let registry = Registry::new(url, &library_dir);
+
+    if !registry.is_cloned() {
+        return Err(Error::RegistrySync {
+            name: "personal".into(),
+            message: "The library is not a registry checkout. Run 'akm skills sync' first.".into(),
+        });
+    }
+
+    let library = Library::load_checked(paths)?;
+
+    // Ask the remote where it stands once, not once per spec.
+    registry.refresh()?;
+    let drift = registry.drift()?;
+
+    let pending: Vec<&Spec> = library
+        .specs
+        .iter()
+        .filter(|s| drift.state_of(&s.id).has_local_changes())
+        .collect();
+
+    if pending.is_empty() {
+        println!("Nothing to publish — every spec matches the registry.");
+        return Ok(());
+    }
+
+    let ids: Vec<String> = pending.iter().map(|s| s.id.clone()).collect();
+    let mut pathspecs: Vec<String> = Vec::new();
+    for spec in &pending {
+        pathspecs.extend(spec.pathspecs());
+    }
+
+    if dry_run {
+        println!("Dry run — {} spec(s) would be published:", ids.len());
+        for id in &ids {
+            println!("  {id}");
+        }
+        println!();
+        println!("Changes that would be pushed:");
+        println!("{}", registry.diff_local(&pathspecs)?);
+        return Ok(());
+    }
+
+    // A spec the remote also changed is rebased ours-wins, same as the
+    // single-spec path.
+    let diverged: Vec<String> = pending
+        .iter()
+        .filter(|s| drift.state_of(&s.id) == DriftState::Diverged)
+        .flat_map(|s| s.pathspecs())
+        .collect();
+    if !diverged.is_empty() {
+        registry.adopt_remote_then_keep_local(&diverged)?;
+    }
+
+    let message = format!("feat: publish {} spec(s)\n\n{}", ids.len(), ids.join(", "));
+
+    match registry.publish(&pathspecs, &message)? {
+        PublishOutcome::NothingToDo => println!("Nothing to publish."),
+        PublishOutcome::Published => {
+            println!("Published {} spec(s):", ids.len());
+            for id in &ids {
+                println!("  {id}");
+            }
+            println!();
+            println!("Pushed to {}", registry.url());
+        }
+    }
+
+    Ok(())
+}
+
 /// Show what publishing would send, without touching the remote.
 fn show_dry_run(registry: &Registry, spec: &Spec, state: DriftState) -> Result<()> {
     let pathspecs = spec.pathspecs();

--- a/src/library/spec.rs
+++ b/src/library/spec.rs
@@ -57,6 +57,18 @@ impl SpecType {
         }
     }
 
+    /// The sidecar's path relative to the library root.
+    ///
+    /// Distinct from [`Self::pathspecs`], which covers a skill's whole
+    /// directory: staging metadata must never sweep in an in-flight `SKILL.md`
+    /// edit, so a metadata commit stages this and nothing else.
+    pub fn sidecar_pathspec(&self, id: &str) -> String {
+        match self {
+            SpecType::Skill => format!("skills/{id}/akm.json"),
+            SpecType::Agent => format!("agents/{id}.akm.json"),
+        }
+    }
+
     /// Map a path inside a library tree back to the spec id that owns it.
     ///
     /// Returns `None` for paths that belong to no spec (`library.json`,
@@ -279,6 +291,11 @@ impl Spec {
         self.spec_type.pathspecs(&self.id)
     }
 
+    /// This spec's sidecar path, relative to the library root.
+    pub fn sidecar_pathspec(&self) -> String {
+        self.spec_type.sidecar_pathspec(&self.id)
+    }
+
     /// Create a new spec with minimal required fields. Other fields are defaults.
     pub fn new(
         id: impl Into<String>,
@@ -325,5 +342,25 @@ impl Spec {
             SpecType::Skill => library_dir.join("skills").join(&self.id).join("SKILL.md"),
             SpecType::Agent => library_dir.join("agents").join(format!("{}.md", self.id)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_pathspec_covers_only_the_metadata_file() {
+        assert_eq!(
+            SpecType::Skill.sidecar_pathspec("alpha"),
+            "skills/alpha/akm.json"
+        );
+        assert_eq!(
+            SpecType::Agent.sidecar_pathspec("bot"),
+            "agents/bot.akm.json"
+        );
+        // The distinction that matters: a skill's full pathspec is its whole
+        // directory, so staging metadata must not use it.
+        assert_eq!(SpecType::Skill.pathspecs("alpha"), vec!["skills/alpha"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,9 +233,12 @@ enum SkillsCommands {
         /// Drop local overrides and follow the registry's defaults
         #[arg(long, conflicts_with = "publish")]
         adopt: bool,
-        /// Make this machine's core choices the registry defaults
+        /// Promote this machine's core choices and push them to the registry
         #[arg(long)]
         publish: bool,
+        /// Preview changes without applying
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Regenerate library.json from disk
     Libgen,
@@ -400,13 +403,18 @@ fn main() -> ExitCode {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
                     commands::skills::revert::run(&paths, &config, &id, remote, force, &tool_dirs)
                 }
-                Some(SkillsCommands::Core { adopt, publish }) => {
+                Some(SkillsCommands::Core {
+                    adopt,
+                    publish,
+                    dry_run,
+                }) => {
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
                     let action = match (adopt, publish) {
                         (true, _) => commands::skills::core::CoreAction::Adopt,
                         (_, true) => commands::skills::core::CoreAction::Publish,
                         _ => commands::skills::core::CoreAction::Show,
                     };
-                    commands::skills::core::run(&paths, action, &tool_dirs)
+                    commands::skills::core::run(&paths, &config, action, &tool_dirs, dry_run)
                 }
                 Some(SkillsCommands::SessionSetup {
                     staging_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,9 +203,9 @@ enum SkillsCommands {
     },
     /// Publish spec to personal registry
     Publish {
-        /// Spec ID to publish
+        /// Spec ID to publish. Omit to publish everything pending.
         #[arg(add = ArgValueCandidates::new(SpecIdCompleter))]
-        id: String,
+        id: Option<String>,
         /// Preview changes without applying
         #[arg(long)]
         dry_run: bool,
@@ -393,7 +393,10 @@ fn main() -> ExitCode {
                 }
                 Some(SkillsCommands::Publish { id, dry_run }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
-                    commands::skills::publish::run(&paths, &config, &id, dry_run)
+                    match id {
+                        Some(id) => commands::skills::publish::run(&paths, &config, &id, dry_run),
+                        None => commands::skills::publish::run_all(&paths, &config, dry_run),
+                    }
                 }
                 Some(SkillsCommands::Diff { id }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -176,16 +176,27 @@ impl Registry {
 
         Git::add_path(&self.dir, &refs)?;
         if Git::is_staging_clean(&self.dir)? {
+            // A commit from an earlier run whose push failed is still ours to
+            // land: staging is clean, but the remote has never seen it.
+            if Git::commits_ahead(&self.dir)? > 0 {
+                self.push()?;
+                return Ok(PublishOutcome::Published);
+            }
             return Ok(PublishOutcome::NothingToDo);
         }
 
         Git::commit(&self.dir, message)?;
+        self.push()?;
+
+        Ok(PublishOutcome::Published)
+    }
+
+    /// Push, reporting a failure as a registry-sync error.
+    fn push(&self) -> Result<()> {
         Git::push(&self.dir).map_err(|e| Error::RegistrySync {
             name: "personal".into(),
             message: format!("Push failed: {e}"),
-        })?;
-
-        Ok(PublishOutcome::Published)
+        })
     }
 
     /// Rebase local work onto the remote for one set of paths, ours winning.

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -39,10 +39,11 @@ fn test_skills_help_output_snapshot() {
 }
 
 /// The drift commands are the user-facing half of the sync rework, so their
-/// contract is pinned.
+/// contract is pinned. `publish` is on the list because its id is optional —
+/// omitting it publishes everything pending, and that has to stay visible.
 #[test]
 fn test_drift_command_help_snapshots() {
-    for command in ["diff", "revert", "core"] {
+    for command in ["diff", "revert", "core", "publish"] {
         let output = cargo_bin_cmd!("akm")
             .args(["skills", command, "--help"])
             .output()

--- a/tests/skills_core_publish_test.rs
+++ b/tests/skills_core_publish_test.rs
@@ -1,0 +1,228 @@
+//! End-to-end `akm skills core --publish` against a real personal registry.
+//!
+//! Promoting this machine's core choices is one intent, so it must be one
+//! commit and one push however many specs it names — and it must carry only
+//! the sidecars, never a `SKILL.md` that happens to be under edit.
+
+use akm::commands::skills::{core, sync};
+use akm::config::Config;
+use akm::library::tool_dirs::ToolDirs;
+use akm::paths::Paths;
+use akm::registry::Registry;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn identify(dir: &Path) {
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn skill_md(id: &str, body: &str) -> String {
+    format!("---\nname: {id}\ndescription: desc for {id}\n---\n{body}\n")
+}
+
+struct Env {
+    _tmp: TempDir,
+    /// The bare repository standing in for the remote.
+    origin: PathBuf,
+    /// A second checkout, standing in for another machine.
+    other: PathBuf,
+    paths: Paths,
+    config: Config,
+    home: PathBuf,
+}
+
+impl Env {
+    fn new() -> Self {
+        let tmp = TempDir::new().unwrap();
+        let origin = tmp.path().join("origin.git");
+        git(tmp.path(), &["init", "--bare", "-b", "main", "origin.git"]);
+
+        // Seed the registry through a throwaway clone.
+        let seed = tmp.path().join("seed");
+        git(
+            tmp.path(),
+            &["clone", "--quiet", &origin.to_string_lossy(), "seed"],
+        );
+        identify(&seed);
+        for id in ["alpha", "beta", "gamma"] {
+            write(
+                &seed.join(format!("skills/{id}/SKILL.md")),
+                &skill_md(id, "v1"),
+            );
+        }
+        git(&seed, &["add", "-A"]);
+        git(&seed, &["commit", "-m", "initial"]);
+        git(&seed, &["push", "--quiet", "-u", "origin", "main"]);
+
+        let other = tmp.path().join("other");
+        git(
+            tmp.path(),
+            &["clone", "--quiet", &origin.to_string_lossy(), "other"],
+        );
+        identify(&other);
+
+        let home = tmp.path().join("home");
+        let paths = Paths::from_roots(
+            &tmp.path().join("data"),
+            &tmp.path().join("config"),
+            &tmp.path().join("cache"),
+            &home,
+        );
+
+        let mut config = Config::default();
+        config.skills.personal_registry = Some(origin.to_string_lossy().to_string());
+
+        Self {
+            _tmp: tmp,
+            origin,
+            other,
+            paths,
+            config,
+            home,
+        }
+    }
+
+    fn sync(&self) {
+        let registry = Registry::new(
+            self.config.registry_url().unwrap(),
+            self.paths.library_dir(),
+        );
+        sync::execute(&self.paths, &registry, &ToolDirs::builtin(&self.home)).unwrap();
+        identify(&self.paths.library_dir());
+    }
+
+    fn library_file(&self, rel: &str) -> PathBuf {
+        self.paths.library_dir().join(rel)
+    }
+
+    /// Make pushes to the remote fail while fetches keep working.
+    fn break_push(&self) {
+        let hook = self.origin.join("hooks").join("pre-receive");
+        write(&hook, "#!/bin/sh\nexit 1\n");
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn restore_push(&self) {
+        std::fs::remove_file(self.origin.join("hooks").join("pre-receive")).unwrap();
+    }
+
+    /// What the registry holds for `rel`, as seen from the other checkout.
+    fn remote_content(&self, rel: &str) -> String {
+        git(&self.other, &["pull", "--quiet", "--ff-only"]);
+        std::fs::read_to_string(self.other.join(rel)).unwrap()
+    }
+
+    fn commit_count(&self) -> u32 {
+        git(&self.paths.library_dir(), &["rev-list", "--count", "HEAD"])
+            .parse()
+            .unwrap()
+    }
+
+    /// Switch `ids` on as this machine's deviation, the way the TUI does.
+    ///
+    /// The sync is not incidental: `library.json` carries the *effective* core
+    /// value, and it is only folded in when the overrides are applied. Writing
+    /// `local.json` alone would leave the promotion reading the old default.
+    fn set_local_core(&self, ids: &[&str]) {
+        let mut map = serde_json::Map::new();
+        for id in ids {
+            map.insert((*id).to_string(), serde_json::Value::Bool(true));
+        }
+        let json = serde_json::json!({ "core": map });
+        write(
+            &self.paths.local_json(),
+            &serde_json::to_string_pretty(&json).unwrap(),
+        );
+        self.sync();
+    }
+
+    fn core_publish(&self) -> akm::error::Result<()> {
+        core::run(
+            &self.paths,
+            &self.config,
+            core::CoreAction::Publish,
+            &ToolDirs::builtin(&self.home),
+            false,
+        )
+    }
+}
+
+#[test]
+fn publishing_core_defaults_makes_exactly_one_commit() {
+    let env = Env::new();
+    env.sync();
+
+    // An unrelated content edit that must NOT be swept into the metadata commit.
+    write(
+        &env.library_file("skills/alpha/SKILL.md"),
+        &skill_md("alpha", "work in progress"),
+    );
+
+    env.set_local_core(&["alpha", "beta", "gamma"]);
+    let before = env.commit_count();
+
+    env.core_publish().unwrap();
+
+    assert_eq!(env.commit_count(), before + 1, "one intent, one commit");
+
+    // All three sidecars reached the registry with core: true.
+    for id in ["alpha", "beta", "gamma"] {
+        let sidecar = env.remote_content(&format!("skills/{id}/akm.json"));
+        assert!(
+            sidecar.contains("\"core\": true"),
+            "{id} sidecar: {sidecar}"
+        );
+    }
+
+    // The in-flight SKILL.md edit stayed home.
+    assert!(env.remote_content("skills/alpha/SKILL.md").contains("v1"));
+}
+
+#[test]
+fn a_failed_push_keeps_the_deviations_for_a_retry() {
+    let env = Env::new();
+    env.sync();
+    env.set_local_core(&["alpha", "beta"]);
+
+    env.break_push();
+    assert!(env.core_publish().is_err());
+
+    // local.json must still hold the deviations, or the retry has nothing to
+    // promote and the remote never receives them.
+    let local = std::fs::read_to_string(env.paths.local_json()).unwrap();
+    assert!(
+        local.contains("alpha"),
+        "deviations cleared too early: {local}"
+    );
+
+    env.restore_push();
+    env.core_publish().unwrap();
+    assert!(env
+        .remote_content("skills/alpha/akm.json")
+        .contains("\"core\": true"));
+}

--- a/tests/skills_core_publish_test.rs
+++ b/tests/skills_core_publish_test.rs
@@ -204,6 +204,27 @@ fn publishing_core_defaults_makes_exactly_one_commit() {
 }
 
 #[test]
+fn a_dry_run_publishes_nothing() {
+    let env = Env::new();
+    env.sync();
+    env.set_local_core(&["alpha", "beta"]);
+    let before = env.commit_count();
+
+    core::run(
+        &env.paths,
+        &env.config,
+        core::CoreAction::Publish,
+        &ToolDirs::builtin(&env.home),
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(env.commit_count(), before, "dry run must not commit");
+    let local = std::fs::read_to_string(env.paths.local_json()).unwrap();
+    assert!(local.contains("alpha"), "dry run must not clear deviations");
+}
+
+#[test]
 fn a_failed_push_keeps_the_deviations_for_a_retry() {
     let env = Env::new();
     env.sync();

--- a/tests/skills_drift_commands_test.rs
+++ b/tests/skills_drift_commands_test.rs
@@ -55,6 +55,12 @@ impl Env {
         git(&origin, &["init", "-b", "main"]);
         git(&origin, &["config", "user.email", "test@example.com"]);
         git(&origin, &["config", "user.name", "Test"]);
+        // The origin is a real checkout, not a bare repo, so a push to its
+        // current branch is refused unless it is told to take the update.
+        git(
+            &origin,
+            &["config", "receive.denyCurrentBranch", "updateInstead"],
+        );
         for id in ["alpha", "beta"] {
             write(
                 &origin.join(format!("skills/{id}/SKILL.md")),
@@ -98,6 +104,9 @@ impl Env {
             self.paths.library_dir(),
         );
         sync::execute(&self.paths, &registry, &self.tool_dirs()).unwrap();
+        let library_dir = self.paths.library_dir();
+        git(&library_dir, &["config", "user.email", "test@example.com"]);
+        git(&library_dir, &["config", "user.name", "Test"]);
     }
 
     fn library_file(&self, rel: &str) -> PathBuf {
@@ -274,7 +283,14 @@ fn core_show_lists_the_globally_mounted_specs() {
     let env = Env::new();
     env.sync();
 
-    core::run(&env.paths, CoreAction::Show, &env.tool_dirs()).unwrap();
+    core::run(
+        &env.paths,
+        &env.config,
+        CoreAction::Show,
+        &env.tool_dirs(),
+        false,
+    )
+    .unwrap();
 
     let library = Library::load_from(&env.paths.library_json()).unwrap();
     assert_eq!(library.core_ids(), vec!["alpha"]);
@@ -292,7 +308,14 @@ fn core_adopt_drops_local_overrides_and_relinks() {
     env.sync();
     assert!(!env.home.join(".claude/skills/alpha").exists());
 
-    core::run(&env.paths, CoreAction::Adopt, &env.tool_dirs()).unwrap();
+    core::run(
+        &env.paths,
+        &env.config,
+        CoreAction::Adopt,
+        &env.tool_dirs(),
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         LocalOverrides::load_from(&env.paths.local_json())
@@ -303,8 +326,8 @@ fn core_adopt_drops_local_overrides_and_relinks() {
     assert!(env.home.join(".claude/skills/alpha").is_symlink());
 }
 
-/// `--publish` promotes this machine's choices into the sidecars, which is
-/// what makes them publishable — and leaves the spec showing as changed.
+/// `--publish` promotes this machine's choices into the sidecars *and* sends
+/// them, so the spec comes out level with the registry rather than pending.
 #[test]
 fn core_publish_promotes_overrides_into_the_sidecars() {
     let env = Env::new();
@@ -315,7 +338,14 @@ fn core_publish_promotes_overrides_into_the_sidecars() {
     overrides.save_to(&env.paths.local_json()).unwrap();
     env.sync();
 
-    core::run(&env.paths, CoreAction::Publish, &env.tool_dirs()).unwrap();
+    core::run(
+        &env.paths,
+        &env.config,
+        CoreAction::Publish,
+        &env.tool_dirs(),
+        false,
+    )
+    .unwrap();
 
     let sidecar = std::fs::read_to_string(env.library_file("skills/beta/akm.json")).unwrap();
     assert!(sidecar.contains("\"core\": true"));
@@ -326,8 +356,14 @@ fn core_publish_promotes_overrides_into_the_sidecars() {
         0
     );
 
+    // The promotion reached the registry, so nothing is left to publish.
+    assert!(
+        std::fs::read_to_string(env.origin.join("skills/beta/akm.json"))
+            .unwrap()
+            .contains("\"core\": true")
+    );
     let registry = Registry::new(env.config.registry_url().unwrap(), env.paths.library_dir());
-    assert!(registry
+    assert!(!registry
         .drift()
         .unwrap()
         .state_of("beta")

--- a/tests/skills_publish_test.rs
+++ b/tests/skills_publish_test.rs
@@ -287,6 +287,34 @@ fn publishing_a_new_skill_sends_all_of_its_files() {
         .contains("human prose"));
 }
 
+/// Publishing without an id is one intent covering many specs, so it must cost
+/// one commit however many it sweeps up.
+#[test]
+fn publishing_everything_pending_makes_one_commit() {
+    let env = Env::new();
+    env.sync();
+
+    write(
+        &env.library_file("skills/alpha/SKILL.md"),
+        &skill_md("alpha", "alpha edited"),
+    );
+    write(
+        &env.library_file("skills/beta/SKILL.md"),
+        &skill_md("beta", "beta edited"),
+    );
+    let before = env.commit_count();
+
+    publish::run_all(&env.paths, &env.config, false).unwrap();
+
+    assert_eq!(env.commit_count(), before + 1);
+    assert!(env
+        .remote_content("skills/alpha/SKILL.md")
+        .contains("alpha edited"));
+    assert!(env
+        .remote_content("skills/beta/SKILL.md")
+        .contains("beta edited"));
+}
+
 /// A push that fails after its commit landed leaves work stranded: staging is
 /// clean, so the next publish would otherwise report nothing to do forever.
 #[test]

--- a/tests/skills_publish_test.rs
+++ b/tests/skills_publish_test.rs
@@ -8,6 +8,7 @@ use akm::config::Config;
 use akm::library::tool_dirs::ToolDirs;
 use akm::paths::Paths;
 use akm::registry::Registry;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
@@ -45,6 +46,8 @@ fn skill_md(id: &str, body: &str) -> String {
 
 struct Env {
     _tmp: TempDir,
+    /// The bare repository standing in for the remote.
+    origin: PathBuf,
     /// A second checkout, standing in for another machine.
     other: PathBuf,
     paths: Paths,
@@ -95,11 +98,33 @@ impl Env {
 
         Self {
             _tmp: tmp,
+            origin,
             other,
             paths,
             config,
             home,
         }
+    }
+
+    /// Make pushes to the remote fail while fetches keep working.
+    ///
+    /// A rejecting `pre-receive` hook rather than a broken remote URL: publish
+    /// fetches before it commits, so an unreachable remote would fail early and
+    /// the commit under test would never land.
+    fn break_push(&self) {
+        let hook = self.origin.join("hooks").join("pre-receive");
+        write(&hook, "#!/bin/sh\nexit 1\n");
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn restore_push(&self) {
+        std::fs::remove_file(self.origin.join("hooks").join("pre-receive")).unwrap();
+    }
+
+    fn commit_count(&self) -> u32 {
+        git(&self.paths.library_dir(), &["rev-list", "--count", "HEAD"])
+            .parse()
+            .unwrap()
     }
 
     fn sync(&self) {
@@ -260,6 +285,33 @@ fn publishing_a_new_skill_sends_all_of_its_files() {
     assert!(env
         .remote_content("skills/gamma/akm.json")
         .contains("human prose"));
+}
+
+/// A push that fails after its commit landed leaves work stranded: staging is
+/// clean, so the next publish would otherwise report nothing to do forever.
+#[test]
+fn a_commit_whose_push_failed_is_retried_by_the_next_publish() {
+    let env = Env::new();
+    env.sync();
+
+    write(
+        &env.library_file("skills/alpha/SKILL.md"),
+        &skill_md("alpha", "edited locally"),
+    );
+
+    // The commit lands, the push does not.
+    env.break_push();
+    assert!(env.publish("alpha").is_err());
+    assert_eq!(env.commit_count(), 2, "the commit must have landed");
+
+    // The retry must push the commit already sitting on HEAD rather than
+    // reporting that there is nothing to do.
+    env.restore_push();
+    env.publish("alpha").unwrap();
+
+    assert!(env
+        .remote_content("skills/alpha/SKILL.md")
+        .contains("edited locally"));
 }
 
 #[test]

--- a/tests/snapshots/help_test__core_help_output.snap
+++ b/tests/snapshots/help_test__core_help_output.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/help_test.rs
-assertion_line: 51
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
 Show or reconcile which specs are globally mounted
@@ -9,6 +8,7 @@ Usage: akm skills core [OPTIONS]
 
 Options:
       --adopt    Drop local overrides and follow the registry's defaults
-      --publish  Make this machine's core choices the registry defaults
+      --publish  Promote this machine's core choices and push them to the registry
+      --dry-run  Preview changes without applying
   -h, --help     Print help
   -V, --version  Print version

--- a/tests/snapshots/help_test__diff_help_output.snap
+++ b/tests/snapshots/help_test__diff_help_output.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/help_test.rs
-assertion_line: 51
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
 Show what changed locally and in the registry for a spec

--- a/tests/snapshots/help_test__publish_help_output.snap
+++ b/tests/snapshots/help_test__publish_help_output.snap
@@ -1,0 +1,15 @@
+---
+source: tests/help_test.rs
+expression: "String::from_utf8_lossy(&output.stdout).to_string()"
+---
+Publish spec to personal registry
+
+Usage: akm skills publish [OPTIONS] [ID]
+
+Arguments:
+  [ID]  Spec ID to publish. Omit to publish everything pending
+
+Options:
+      --dry-run  Preview changes without applying
+  -h, --help     Print help
+  -V, --version  Print version

--- a/tests/snapshots/help_test__revert_help_output.snap
+++ b/tests/snapshots/help_test__revert_help_output.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/help_test.rs
-assertion_line: 51
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
 Discard local changes to a spec

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/help_test.rs
-assertion_line: 35
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
 Skills management


### PR DESCRIPTION
Toggling 24 skills to `core` in the TUI is a ten-second action. Publishing it
took 24 shell commands and produced 24 commits. This makes one intent cost one
commit.

## What changed

- **`akm skills core --publish` promotes *and* pushes**, in a single commit
  however many specs it names. It stages only `akm.json` sidecars via a new
  `SpecType::sidecar_pathspec`, because `pathspecs()` returns `skills/{id}` —
  the whole directory — and staging that for a metadata commit would sweep in
  a `SKILL.md` under edit.
- **`akm skills publish` with no id** publishes every pending spec as one
  commit and one push. Diverged specs are rebased ours-wins first, same as the
  single-spec path.
- **`--dry-run` on both.**
- **Fix: a commit whose push failed was never retried.** `Registry::publish`
  returned `NothingToDo` whenever staging was clean, so a push that failed
  *after* its commit landed left the commit local forever. It now pushes
  commits already on `HEAD`.

`local.json` stays an experiment sandbox — toggle freely, promote sometimes.
Deviations are cleared only once the push has landed, so a failed publish is
retryable rather than lost.

## Notes for review

- **`core_publish_promotes_overrides_into_the_sidecars` changed assertion.** It
  asserted that `--publish` leaves the spec showing as locally changed —
  exactly what this inverts. Now asserts the sidecar reached the origin and
  drift is clean. It is the only pre-existing assertion I changed.
- **Push failure is induced with a rejecting `pre-receive` hook**, not a broken
  remote URL. `publish::run` fetches before it commits, so an unreachable
  remote fails early and the commit under test never lands — the test would
  have passed without the fix.
- **`skills publish --help` is now snapshotted**, which is where `[ID]` being
  optional shows up as a contract. The dry-run output wording itself is not
  pinned; the behaviour is covered by `a_dry_run_publishes_nothing`.

## Out of scope

`library.json` is in `.git/info/exclude` yet still tracked, so it is
permanently modified in the working tree. Staging here is by explicit pathspec
rather than `-A`, so it is avoided rather than fixed. Needs `git rm --cached`
plus a migration — worth a separate issue.

## Verification

```
cargo test                                → 25 binaries, 0 failures
cargo clippy --all-targets -- -D warnings → clean
cargo fmt --check                         → clean
```
