### PR TITLE
chore(release): 1.0.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.0.0-rc5
 
 - Publishing is batched: one intent is one commit
   - `akm skills core --publish` now promotes *and* pushes, in a single commit,
@@ -7,6 +7,12 @@
   - `--dry-run` on both
 - Fix a commit whose push failed never being retried — publish now pushes
   commits already on `HEAD` instead of reporting nothing to do
+- Fix the cursor jumping in `akm skills status` when a spec changes section:
+  `c`, `a` and `r` now hold the cursor on its screen line and move it to the
+  neighbour, instead of scrolling the window to wherever the spec landed
+- Sync evicts a stale `library.json` left inside the registry checkout by an
+  earlier layout — restored to `HEAD` when tracked, deleted when it is the
+  untracked copy rc4 hid with `.git/info/exclude`
 
 # 1.0.0-rc4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akm"
-version = "1.0.0-rc4"
+version = "1.0.0-rc5"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akm"
-version = "1.0.0-rc4"
+version = "1.0.0-rc5"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Agent Kit Manager — manage reusable LLM skills, artifacts, and instructions"

--- a/tests/snapshots/update_test__version_output.snap
+++ b/tests/snapshots/update_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/update_test.rs
 expression: stdout.trim()
 ---
-akm 1.0.0-rc4
+akm 1.0.0-rc5


### PR DESCRIPTION
Cuts 1.0.0-rc5.

- `version` in `Cargo.toml` (and the `Cargo.lock` echo) — manual, per AGENTS.md
- `tests/snapshots/update_test__version_output.snap` follows the bump
- `CHANGELOG.md`: the Unreleased section becomes `# 1.0.0-rc5`, plus the two
  fixes merged since rc4 that had not been written down — the status-dashboard
  cursor (#36) and the stale `library.json` eviction (#34)

Tagged as a normal release, not a prerelease: with no 1.0.0 final yet, the
newest rc has to resolve as "Latest" for `akm update` and the installer.
