### PR TITLE
feat: add akm uninstall + akm disable/enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
 
+- Add `akm uninstall` — removes the binary, ~/.bashrc integration block,
+  global spec symlinks, config, caches, and machine-local metadata
+  (`library.json`, `local.json`, `tools.json`). Preserves artifacts, the
+  legacy global instructions file, and the library (the registry checkout,
+  which may hold unpublished local edits); `--purge` removes those too.
+  `--yes` skips the confirmation prompt.
+- Add `akm disable` / `akm enable` — reversible vanilla mode. `disable`
+  makes new shells skip the claude/copilot/opencode/pi wrappers and clears
+  global core symlinks without deleting anything; `enable` restores both.
+  Useful for checking default harness behavior without akm.
 - **Breaking**: remove `akm skills load`, `akm skills unload`, and `akm skills loaded`
   - `skills add`/`remove` already refresh the active session's symlinks, so
     load/unload only offered manifest-free session loading — niche and unused

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Commands:
   artifacts     Artifact sync
   instructions  Global instruction management
   completions   Generate shell completion script
+  disable       Turn off shell integration so harnesses run vanilla
+  enable        Re-enable shell integration after akm disable
+  uninstall     Remove akm from this machine
 ```
 
 ### Skills
@@ -235,6 +238,31 @@ akm update --check               # check without installing
 
 `akm update` also rewrites `akm-init.sh` from the new binary, so shell-side
 changes land without a second `akm setup`. Restart your shell to pick them up.
+
+### Disabling and Uninstalling
+
+```bash
+akm disable            # new shells get vanilla claude/copilot/opencode/pi; nothing deleted
+akm enable             # restore wrappers and global core symlinks
+akm uninstall          # remove akm — preserves artifacts and the library checkout
+akm uninstall --purge  # remove everything, including artifacts and the library
+```
+
+`akm disable` is the way to check default harness behavior without akm: it
+removes the global core-spec symlinks and makes new shells skip the tool
+wrappers, while leaving config, library, and manifests intact. For a one-off
+bypass in the current shell, `command claude` runs the real binary without
+the wrapper (the wrappers are shell functions, and `command` skips function
+lookup).
+
+`akm uninstall` preserves `~/.akm/artifacts` and the library — the checkout
+of your personal registry, which may hold unpublished local edits. Published
+content is recoverable by re-cloning; anything marked `*` or `!` in
+`akm skills status` is not. `--purge` deletes both, unpublished changes
+included.
+
+Instruction files previously distributed to tool dirs (e.g. `~/.claude/CLAUDE.md`)
+are never deleted by any of these commands — they may contain your own edits.
 
 ### Shell Completions
 

--- a/src/commands/disable.rs
+++ b/src/commands/disable.rs
@@ -1,0 +1,41 @@
+//! `akm disable` — restore vanilla harness entrypoints without removing anything.
+//!
+//! Creates the `disabled` sentinel (checked by akm-init.sh at source time,
+//! so new shells skip the claude/copilot/opencode/pi wrappers) and clears
+//! the global core-spec symlinks from tool directories. Config, library,
+//! and manifests are untouched. Reversed by `akm enable`.
+
+use crate::error::{IoContext, Result};
+use crate::library::symlinks;
+use crate::library::tool_dirs::ToolDirs;
+use crate::paths::Paths;
+
+/// Run the `akm disable` command. Idempotent.
+pub fn run(paths: &Paths, tool_dirs: &ToolDirs) -> Result<()> {
+    let sentinel = paths.disabled_sentinel();
+    let already = sentinel.is_file();
+
+    std::fs::create_dir_all(paths.config_dir()).io_context(format!(
+        "Creating config directory {}",
+        paths.config_dir().display()
+    ))?;
+    std::fs::write(&sentinel, "").io_context(format!("Writing sentinel {}", sentinel.display()))?;
+
+    let cleared = symlinks::clear_all(tool_dirs.dirs())?;
+
+    if already {
+        println!("akm was already disabled.");
+    } else {
+        println!("akm disabled.");
+    }
+    println!("  - New shells get vanilla claude/copilot/opencode/pi (no wrappers)");
+    println!("  - Removed {cleared} global spec symlink(s) from tool directories");
+    println!();
+    println!("This shell still has the wrappers. To drop them now:");
+    println!("  unset -f claude copilot opencode pi");
+    println!();
+    println!("Instruction files distributed to tool dirs (e.g. ~/.claude/CLAUDE.md)");
+    println!("are left in place. Re-enable with: akm enable");
+
+    Ok(())
+}

--- a/src/commands/enable.rs
+++ b/src/commands/enable.rs
@@ -1,0 +1,35 @@
+//! `akm enable` — re-activate shell integration after `akm disable`.
+//!
+//! Removes the `disabled` sentinel and rebuilds global core-spec symlinks
+//! from the library (skipped gracefully if the library doesn't exist yet).
+
+use crate::error::{IoContext, Result};
+use crate::library::symlinks;
+use crate::library::tool_dirs::ToolDirs;
+use crate::library::Library;
+use crate::paths::Paths;
+
+/// Run the `akm enable` command. Idempotent.
+pub fn run(paths: &Paths, tool_dirs: &ToolDirs) -> Result<()> {
+    let sentinel = paths.disabled_sentinel();
+    if sentinel.is_file() {
+        std::fs::remove_file(&sentinel)
+            .io_context(format!("Removing sentinel {}", sentinel.display()))?;
+        println!("akm enabled.");
+    } else {
+        println!("akm was not disabled.");
+    }
+
+    let rebuilt = match Library::load(paths) {
+        Ok(library) => {
+            let core_specs = library.core_specs();
+            symlinks::rebuild_core(&core_specs, &paths.library_dir(), tool_dirs.dirs())?
+        }
+        Err(_) => 0, // No library yet — nothing to symlink
+    };
+    println!("  - Restored {rebuilt} global core symlink(s)");
+    println!();
+    println!("Start a new shell to restore the claude/copilot/opencode/pi wrappers.");
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,8 +3,11 @@
 pub mod artifacts;
 pub mod completions;
 pub mod config;
+pub mod disable;
+pub mod enable;
 pub mod instructions;
 pub mod setup;
 pub mod skills;
 pub mod sync;
+pub mod uninstall;
 pub mod update;

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,0 +1,161 @@
+//! `akm uninstall` — remove akm from the machine.
+//!
+//! Default mode preserves user content: artifacts (`~/.akm/artifacts`),
+//! the legacy global instructions file (`~/.akm/global-instructions.md`),
+//! and the library (`$XDG_DATA_HOME/akm/library/` — the checkout of the
+//! personal registry, which may hold unpublished local edits). `--purge`
+//! removes everything.
+//!
+//! Instruction files distributed into tool dirs (e.g. `~/.claude/CLAUDE.md`)
+//! are never touched — they may contain user edits that drifted from the
+//! library copy, so deleting them could destroy user content.
+//!
+//! The binary itself is removed last, so a failure partway through leaves
+//! a working `akm` to re-run (all steps tolerate already-missing targets).
+
+use crate::commands::setup::Prompter;
+use crate::error::{IoContext, Result};
+use crate::library::symlinks;
+use crate::library::tool_dirs::ToolDirs;
+use crate::paths::Paths;
+use crate::shell;
+use std::path::Path;
+
+/// Run the `akm uninstall` command.
+///
+/// Prompts for confirmation unless `yes` is set (Enter defaults to no).
+pub fn run(
+    paths: &Paths,
+    tool_dirs: &ToolDirs,
+    purge: bool,
+    yes: bool,
+    prompter: &mut dyn Prompter,
+) -> Result<()> {
+    print_plan(paths, purge);
+
+    if !yes {
+        let confirmed = prompter.confirm("Proceed with uninstall?", false)?;
+        if !confirmed {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    remove_files(paths, tool_dirs, purge)?;
+    remove_binary()?;
+
+    println!();
+    println!("akm uninstalled.");
+    if !purge {
+        println!("Preserved:");
+        println!("  {}", paths.default_artifacts_dir().display());
+        println!("  {}", paths.legacy_global_instructions().display());
+        println!("  {}", paths.library_dir().display());
+    }
+    println!("Restart your shell to drop the claude/copilot/opencode/pi wrappers.");
+    Ok(())
+}
+
+/// Print what will be removed and what will be preserved.
+fn print_plan(paths: &Paths, purge: bool) {
+    println!("This will remove:");
+    println!("  - this binary ({})", current_exe_display());
+    println!("  - the akm block in ~/.bashrc");
+    println!("  - global spec symlinks in tool directories");
+    println!("  - config: {}", paths.config_dir().display());
+    println!("  - cache:  {}", paths.cache_dir().display());
+    if purge {
+        println!(
+            "  - data:   {} (including the library checkout — any",
+            paths.data_dir().display()
+        );
+        println!("            unpublished local changes are lost)");
+        println!("  - {} (including artifacts)", paths.akm_home().display());
+    } else {
+        println!(
+            "  - data:   {} (library.json, local.json, tools.json, shell/)",
+            paths.data_dir().display()
+        );
+        println!();
+        println!("Preserved:");
+        println!("  - artifacts: {}", paths.default_artifacts_dir().display());
+        println!(
+            "  - legacy global instructions: {}",
+            paths.legacy_global_instructions().display()
+        );
+        println!(
+            "  - library (registry checkout): {}",
+            paths.library_dir().display()
+        );
+    }
+    println!();
+    println!("Instruction files distributed to tool dirs (e.g. ~/.claude/CLAUDE.md)");
+    println!("are left in place — they may contain your own edits.");
+    println!();
+}
+
+/// Remove akm's files, honoring the preserve set unless `purge`.
+///
+/// Separated from [`run`] so tests can exercise it against temp dirs
+/// without prompting or deleting the test binary.
+pub fn remove_files(paths: &Paths, tool_dirs: &ToolDirs, purge: bool) -> Result<()> {
+    // 1. Shell integration block
+    if shell::unpatch_bashrc(paths)? {
+        println!("Removed akm block from ~/.bashrc");
+    }
+
+    // 2. Global spec symlinks (before tools.json goes away)
+    let cleared = symlinks::clear_all(tool_dirs.dirs())?;
+    if cleared > 0 {
+        println!("Removed {cleared} global spec symlink(s)");
+    }
+
+    // 3. Config dir (config.toml, disabled sentinel)
+    remove_dir_if_exists(paths.config_dir())?;
+
+    // 4. Cache dir (registry caches, staging, update-check cache)
+    remove_dir_if_exists(paths.cache_dir())?;
+
+    // 5. Data dir: everything, or everything except the library checkout
+    if purge {
+        remove_dir_if_exists(paths.data_dir())?;
+        remove_dir_if_exists(paths.akm_home())?;
+    } else {
+        remove_file_if_exists(&paths.library_json())?;
+        remove_file_if_exists(&paths.local_json())?;
+        remove_file_if_exists(&paths.tools_json())?;
+        remove_dir_if_exists(&paths.data_dir().join("shell"))?;
+    }
+
+    Ok(())
+}
+
+/// Delete the running executable. Last step — see module doc.
+fn remove_binary() -> Result<()> {
+    let exe = std::env::current_exe().io_context("Resolving current executable path")?;
+    std::fs::remove_file(&exe).io_context(format!("Removing binary {}", exe.display()))?;
+    println!("Removed binary {}", exe.display());
+    Ok(())
+}
+
+fn current_exe_display() -> String {
+    std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn remove_dir_if_exists(dir: &Path) -> Result<()> {
+    if dir.is_dir() {
+        std::fs::remove_dir_all(dir).io_context(format!("Removing directory {}", dir.display()))?;
+        println!("Removed {}", dir.display());
+    }
+    Ok(())
+}
+
+fn remove_file_if_exists(file: &Path) -> Result<()> {
+    if file.is_file() {
+        std::fs::remove_file(file).io_context(format!("Removing {}", file.display()))?;
+        println!("Removed {}", file.display());
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,32 @@ enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+    /// Turn off shell integration so harnesses run vanilla (reversible)
+    ///
+    /// New shells get the plain claude/copilot/opencode/pi binaries (no
+    /// session wrappers) and global core-spec symlinks are removed from tool
+    /// dirs. Nothing is deleted from config or the library. Undo with
+    /// `akm enable`.
+    ///
+    /// For a one-off bypass in the current shell, `command claude` skips the
+    /// wrapper without disabling anything.
+    Disable,
+    /// Re-enable shell integration after `akm disable`
+    Enable,
+    /// Remove akm from this machine
+    ///
+    /// Removes the binary, the ~/.bashrc integration block, global spec
+    /// symlinks, config, and caches. Preserves artifacts (~/.akm/artifacts),
+    /// legacy global instructions, and the library (the registry checkout,
+    /// which may hold unpublished local edits) unless --purge is given.
+    Uninstall {
+        /// Also delete artifacts, global instructions, and the library
+        #[arg(long)]
+        purge: bool,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 /// Skills subcommands.
@@ -283,11 +309,17 @@ fn main() -> ExitCode {
         }
     };
 
+    // Uninstall must not race the background check, whose cache write would
+    // re-create ~/.cache/akm after uninstall deletes it.
+    let is_uninstall_command = matches!(&cli.command, Some(Commands::Uninstall { .. }));
+
     // Spawn background version check
     let update_rx = {
         match config::Config::load(&paths) {
-            Ok(cfg) => update::version_check::spawn_background_check(&cfg.update, &paths),
-            Err(_) => {
+            Ok(cfg) if !is_uninstall_command => {
+                update::version_check::spawn_background_check(&cfg.update, &paths)
+            }
+            _ => {
                 let (tx, rx) = std::sync::mpsc::channel();
                 let _ = tx.send(update::version_check::CheckResult::Skipped);
                 rx
@@ -445,6 +477,19 @@ fn main() -> ExitCode {
             }
         },
         Some(Commands::Completions { shell }) => commands::completions::run(&shell),
+        Some(Commands::Disable) => {
+            let tool_dirs = akm::library::tool_dirs::ToolDirs::load(&paths);
+            commands::disable::run(&paths, &tool_dirs)
+        }
+        Some(Commands::Enable) => {
+            let tool_dirs = akm::library::tool_dirs::ToolDirs::load(&paths);
+            commands::enable::run(&paths, &tool_dirs)
+        }
+        Some(Commands::Uninstall { purge, yes }) => {
+            let tool_dirs = akm::library::tool_dirs::ToolDirs::load(&paths);
+            let mut prompter = commands::setup::StdinPrompter;
+            commands::uninstall::run(&paths, &tool_dirs, purge, yes, &mut prompter)
+        }
     };
 
     // Print update notice after command output (unless user ran `akm update`)

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -145,6 +145,14 @@ impl Paths {
         self.config_dir.join("config.toml")
     }
 
+    /// `$XDG_CONFIG_HOME/akm/disabled` — sentinel created by `akm disable`.
+    ///
+    /// When present, `akm-init.sh` returns early without defining tool
+    /// wrappers, leaving harness entrypoints vanilla in new shells.
+    pub fn disabled_sentinel(&self) -> PathBuf {
+        self.config_dir.join("disabled")
+    }
+
     // --- Cache dir ---
 
     /// `$XDG_CACHE_HOME/akm` — caches and ephemeral data

--- a/src/shell/akm-init.sh
+++ b/src/shell/akm-init.sh
@@ -12,6 +12,10 @@
 # interactive shell — setting -e would cause the shell to exit on any error.
 # Individual functions handle errors with `|| true` and explicit return codes.
 
+# Respect `akm disable` — skip all integration so harness entrypoints
+# (claude, copilot, opencode, pi) stay vanilla. Re-enable with `akm enable`.
+[[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/akm/disabled" ]] && return 0
+
 # --- Config ---
 
 # Reads config through the akm binary, caching each value in a shell variable

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -138,6 +138,34 @@ fn remove_marker_block(content: &str) -> String {
     result
 }
 
+/// Remove the AKM shell integration block from .bashrc.
+///
+/// Returns `Ok(true)` if a block was found and removed, `Ok(false)` if
+/// .bashrc is missing or contains no AKM block. Used by `akm uninstall`.
+pub fn unpatch_bashrc(paths: &Paths) -> Result<bool> {
+    let bashrc = paths.home().join(".bashrc");
+    if !bashrc.is_file() {
+        return Ok(false);
+    }
+
+    let existing = std::fs::read_to_string(&bashrc).map_err(|e| Error::ShellInitWrite {
+        path: bashrc.clone(),
+        source: e,
+    })?;
+
+    if !existing.contains(BASHRC_MARKER_START) {
+        return Ok(false);
+    }
+
+    let cleaned = remove_marker_block(&existing);
+    std::fs::write(&bashrc, &cleaned).map_err(|e| Error::ShellInitWrite {
+        path: bashrc,
+        source: e,
+    })?;
+
+    Ok(true)
+}
+
 /// Check if .bashrc already contains the AKM marker block.
 ///
 /// Used by setup to report status without re-patching.

--- a/tests/snapshots/help_test__help_output.snap
+++ b/tests/snapshots/help_test__help_output.snap
@@ -15,6 +15,9 @@ Commands:
   artifacts     Artifact sync
   instructions  Global instruction management
   completions   Generate shell completion script
+  disable       Turn off shell integration so harnesses run vanilla (reversible)
+  enable        Re-enable shell integration after `akm disable`
+  uninstall     Remove akm from this machine
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/snapshots/shell_test__shell_init.snap
+++ b/tests/snapshots/shell_test__shell_init.snap
@@ -16,6 +16,10 @@ expression: "akm::shell::shell_init_content()"
 # interactive shell — setting -e would cause the shell to exit on any error.
 # Individual functions handle errors with `|| true` and explicit return codes.
 
+# Respect `akm disable` — skip all integration so harness entrypoints
+# (claude, copilot, opencode, pi) stay vanilla. Re-enable with `akm enable`.
+[[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/akm/disabled" ]] && return 0
+
 # --- Config ---
 
 # Reads config through the akm binary, caching each value in a shell variable

--- a/tests/uninstall_test.rs
+++ b/tests/uninstall_test.rs
@@ -1,0 +1,363 @@
+//! Integration tests for `akm uninstall`, `akm disable`, and `akm enable`.
+//!
+//! All tests use temp directories via `Paths::from_roots` and call the
+//! testable inner functions — never the binary-deleting path.
+
+use akm::commands::setup::Prompter;
+use akm::commands::{disable, enable, uninstall};
+use akm::error::Result;
+use akm::library::spec::{Spec, SpecType};
+use akm::library::tool_dirs::ToolDirs;
+use akm::library::Library;
+use akm::paths::Paths;
+use akm::shell;
+use tempfile::TempDir;
+
+fn test_paths(tmp: &TempDir) -> Paths {
+    Paths::from_roots(
+        &tmp.path().join("data"),
+        &tmp.path().join("config"),
+        &tmp.path().join("cache"),
+        &tmp.path().join("home"),
+    )
+}
+
+fn test_tool_dirs(tmp: &TempDir) -> ToolDirs {
+    ToolDirs::builtin(&tmp.path().join("home"))
+}
+
+/// Lay down a realistic installed-akm file layout.
+///
+/// The library is the registry's git working tree — a `.git` marker stands in
+/// for the clone so tests can assert it survives a default uninstall.
+fn install_fixture(paths: &Paths) {
+    std::fs::create_dir_all(paths.home()).unwrap();
+
+    // Library checkout with one core skill and a .git marker
+    let skill_dir = paths.skills_dir().join("tdd");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# tdd").unwrap();
+    let git_dir = paths.library_dir().join(".git");
+    std::fs::create_dir_all(&git_dir).unwrap();
+    std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+    let mut spec = Spec::new("tdd", SpecType::Skill, "TDD", "Test-driven development");
+    spec.core = true;
+    let library = Library {
+        version: 1,
+        specs: vec![spec],
+    };
+    library.save(paths).unwrap();
+
+    // Machine-local metadata next to library.json
+    std::fs::write(paths.local_json(), "{\"core\":{}}\n").unwrap();
+
+    // tools.json + shell init + bashrc block
+    shell::install_tools_json(paths).unwrap();
+    shell::install_shell_init(paths).unwrap();
+    shell::patch_bashrc(paths).unwrap();
+
+    // Config + cache
+    std::fs::create_dir_all(paths.config_dir()).unwrap();
+    std::fs::write(paths.config_file(), "features = [\"skills\"]\n").unwrap();
+    std::fs::create_dir_all(paths.cache_dir().join("registry")).unwrap();
+
+    // User content in ~/.akm
+    let artifacts = paths.default_artifacts_dir().join("my-repo");
+    std::fs::create_dir_all(&artifacts).unwrap();
+    std::fs::write(artifacts.join("note.md"), "keep me").unwrap();
+    std::fs::write(paths.legacy_global_instructions(), "be nice").unwrap();
+
+    // Global symlinks in tool dirs (what rebuild_core produces). Pi's global
+    // dir is nested (~/.pi/agent) — cover it explicitly.
+    for tool_dir in [
+        paths.home().join(".claude"),
+        paths.home().join(".pi").join("agent"),
+    ] {
+        let skills = tool_dir.join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, skills.join("tdd")).unwrap();
+    }
+}
+
+fn bashrc_content(paths: &Paths) -> String {
+    std::fs::read_to_string(paths.home().join(".bashrc")).unwrap_or_default()
+}
+
+// =============================================================================
+// uninstall::remove_files
+// =============================================================================
+
+#[test]
+fn uninstall_default_preserves_user_content() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), false).unwrap();
+
+    // Removed
+    assert!(!paths.config_dir().exists(), "config dir should be removed");
+    assert!(!paths.cache_dir().exists(), "cache dir should be removed");
+    assert!(!paths.library_json().exists());
+    assert!(!paths.local_json().exists(), "local.json is metadata");
+    assert!(!paths.tools_json().exists());
+    assert!(!paths.data_dir().join("shell").exists());
+    assert!(
+        !paths.home().join(".claude/skills/tdd").is_symlink(),
+        "global symlink should be removed"
+    );
+    assert!(
+        !paths.home().join(".pi/agent/skills/tdd").is_symlink(),
+        "pi global symlink should be removed"
+    );
+    assert!(!bashrc_content(&paths).contains(">>> akm >>>"));
+
+    // Preserved: the library checkout (git clone), artifacts, legacy instructions
+    assert!(paths.skills_dir().join("tdd/SKILL.md").is_file());
+    assert!(paths.library_dir().join(".git/HEAD").is_file());
+    assert!(paths
+        .default_artifacts_dir()
+        .join("my-repo/note.md")
+        .is_file());
+    assert!(paths.legacy_global_instructions().is_file());
+}
+
+#[test]
+fn uninstall_purge_removes_everything() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), true).unwrap();
+
+    assert!(!paths.config_dir().exists());
+    assert!(!paths.cache_dir().exists());
+    assert!(
+        !paths.data_dir().exists(),
+        "data dir (including the library checkout) should be fully removed"
+    );
+    assert!(!paths.akm_home().exists(), "~/.akm should be fully removed");
+    assert!(!bashrc_content(&paths).contains(">>> akm >>>"));
+}
+
+#[test]
+fn uninstall_idempotent_on_missing_files() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    // Nothing installed at all — must not error
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), false).unwrap();
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), true).unwrap();
+}
+
+#[test]
+fn uninstall_leaves_non_symlink_tool_dir_content() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    // A real (non-symlink) skill the user copied in manually
+    let manual = paths.home().join(".claude/skills/hand-rolled");
+    std::fs::create_dir_all(&manual).unwrap();
+    std::fs::write(manual.join("SKILL.md"), "mine").unwrap();
+    // Distributed instructions copy
+    std::fs::write(paths.home().join(".claude/CLAUDE.md"), "instructions").unwrap();
+
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), false).unwrap();
+
+    assert!(manual.join("SKILL.md").is_file());
+    assert!(paths.home().join(".claude/CLAUDE.md").is_file());
+}
+
+#[test]
+fn uninstall_purge_leaves_distributed_instructions() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    std::fs::write(paths.home().join(".claude/CLAUDE.md"), "instructions").unwrap();
+
+    uninstall::remove_files(&paths, &test_tool_dirs(&tmp), true).unwrap();
+
+    // Even --purge never touches copies distributed into tool dirs
+    assert!(paths.home().join(".claude/CLAUDE.md").is_file());
+}
+
+// =============================================================================
+// uninstall::run confirmation
+// =============================================================================
+
+struct DeclinePrompter;
+
+impl Prompter for DeclinePrompter {
+    fn confirm(&mut self, _message: &str, _default_yes: bool) -> Result<bool> {
+        Ok(false)
+    }
+    fn input(&mut self, _message: &str, default: &str) -> Result<String> {
+        Ok(default.to_string())
+    }
+}
+
+#[test]
+fn uninstall_declined_removes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    uninstall::run(
+        &paths,
+        &test_tool_dirs(&tmp),
+        false,
+        false,
+        &mut DeclinePrompter,
+    )
+    .unwrap();
+
+    assert!(paths.config_file().is_file());
+    assert!(paths.library_json().is_file());
+    assert!(bashrc_content(&paths).contains(">>> akm >>>"));
+}
+
+// =============================================================================
+// disable / enable
+// =============================================================================
+
+#[test]
+fn disable_creates_sentinel_and_clears_symlinks() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    disable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+
+    assert!(paths.disabled_sentinel().is_file());
+    assert!(!paths.home().join(".claude/skills/tdd").is_symlink());
+    assert!(!paths.home().join(".pi/agent/skills/tdd").is_symlink());
+    // Library untouched
+    assert!(paths.skills_dir().join("tdd/SKILL.md").is_file());
+    assert!(paths.library_json().is_file());
+}
+
+#[test]
+fn disable_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    disable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+    disable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+    assert!(paths.disabled_sentinel().is_file());
+}
+
+#[test]
+fn enable_removes_sentinel_and_rebuilds_core_symlinks() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    install_fixture(&paths);
+
+    disable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+    enable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+
+    assert!(!paths.disabled_sentinel().exists());
+    assert!(
+        paths.home().join(".claude/skills/tdd").is_symlink(),
+        "core symlink should be rebuilt"
+    );
+    assert!(
+        paths.home().join(".pi/agent/skills/tdd").is_symlink(),
+        "pi core symlink should be rebuilt"
+    );
+}
+
+#[test]
+fn enable_without_disable_or_library_is_graceful() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    // No sentinel, no library
+    enable::run(&paths, &test_tool_dirs(&tmp)).unwrap();
+    assert!(!paths.disabled_sentinel().exists());
+}
+
+// =============================================================================
+// akm-init.sh sentinel check
+// =============================================================================
+
+#[test]
+fn shell_init_returns_early_when_disabled() {
+    // The generated init script must consult the sentinel before defining
+    // wrappers. Run it under bash with XDG_CONFIG_HOME pointed at a dir
+    // containing the sentinel and verify no wrapper functions get defined.
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    shell::install_shell_init(&paths).unwrap();
+
+    let config_akm = tmp.path().join("config").join("akm");
+    std::fs::create_dir_all(&config_akm).unwrap();
+    std::fs::write(config_akm.join("disabled"), "").unwrap();
+
+    let out = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source '{}' && declare -F claude copilot opencode pi; echo \"defined=$?\"",
+            paths.shell_init().display()
+        ))
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .output()
+        .expect("bash should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("defined=1"),
+        "wrappers must not be defined when sentinel present, got: {stdout}"
+    );
+}
+
+#[test]
+fn shell_init_defines_wrappers_when_enabled() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    shell::install_shell_init(&paths).unwrap();
+
+    let out = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source '{}' && declare -F claude copilot opencode pi >/dev/null && echo defined=0",
+            paths.shell_init().display()
+        ))
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .output()
+        .expect("bash should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("defined=0"),
+        "wrappers should be defined without sentinel, got: {stdout}"
+    );
+}
+
+// =============================================================================
+// shell::unpatch_bashrc
+// =============================================================================
+
+#[test]
+fn unpatch_bashrc_removes_block_and_reports() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    std::fs::create_dir_all(paths.home()).unwrap();
+    std::fs::write(paths.home().join(".bashrc"), "# mine\n").unwrap();
+    shell::patch_bashrc(&paths).unwrap();
+
+    let removed = shell::unpatch_bashrc(&paths).unwrap();
+    assert!(removed);
+    let content = bashrc_content(&paths);
+    assert!(content.contains("# mine"));
+    assert!(!content.contains(">>> akm >>>"));
+
+    // Second call: nothing to do
+    assert!(!shell::unpatch_bashrc(&paths).unwrap());
+}
+
+#[test]
+fn unpatch_bashrc_missing_file_returns_false() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    assert!(!shell::unpatch_bashrc(&paths).unwrap());
+}


### PR DESCRIPTION
Replaces #39, reworked against the post-rc5 library model ("the library is the registry's git working tree"). #39 was based pre-rc4 and carried a stray commit from another branch; this is a fresh port off current main, not a rebase.

## What

- **`akm uninstall [--purge] [--yes]`** — removes the binary (last, so a partial failure leaves a working `akm` to re-run), the `~/.bashrc` integration block, global spec symlinks, config, caches, and machine-local metadata (`library.json`, `local.json`, `tools.json`, `shell/`). Every step tolerates missing targets. Confirmation prompt defaults to **no**; `--yes` skips it.
- **`akm disable` / `akm enable`** — reversible vanilla mode. `disable` writes a sentinel (`~/.config/akm/disabled`) that `akm-init.sh` checks at source time before defining the claude/copilot/opencode/pi wrappers, and clears global core symlinks. `enable` removes the sentinel and rebuilds them. Nothing else is touched. One-off bypass without disabling: `command claude`.

## Preserve set (updated for the new library model)

Default uninstall preserves; `--purge` deletes:

- `~/.akm/artifacts/`
- `~/.akm/global-instructions.md` (legacy seed file — cheap to keep)
- `$XDG_DATA_HOME/akm/library/` — now a **git checkout of the personal registry**. Published content is recoverable by re-cloning, but unpublished/diverged local edits (`*`/`!` in `akm skills status`) are not, so the safe default is to preserve. The `--purge` plan output warns that unpublished changes are lost.

Deleted even without `--purge`: `local.json` — machine-local core deviations are metadata, not content.

Never deleted by any command, `--purge` included: instruction copies distributed into tool dirs (`~/.claude/CLAUDE.md` etc.) — they may hold user edits.

## Rework notes (vs #39)

- `enable` rebuilds symlinks with the new `rebuild_core(specs, library_dir, dirs)` signature.
- Sentinel check re-inserted into the rewritten `akm-init.sh` template (after the header, before anything runs); wrapper lists updated to include `pi`.
- The background update check is not spawned for uninstall — its cache write does `create_dir_all` and would resurrect `~/.cache/akm` after removal.
- Tests rebuilt for the new layout: library fixture is a checkout with a `.git` marker; Pi's nested global dir (`~/.pi/agent`) covered explicitly in disable/enable/uninstall assertions.

## Testing

- 14 new integration tests in `tests/uninstall_test.rs` (preserve set, purge, idempotency, decline path, sentinel behavior under real bash, `unpatch_bashrc`).
- Full suite: 26 suites, 471 tests, 0 failures; `clippy --all-targets -D warnings` clean; `fmt --check` clean.
- Snapshot updates limited to the new help lines and the sentinel block in the init-script snapshot.
- Sandboxed end-to-end (fake `HOME`/`XDG_*`, copied binary): `enable` → `disable` → `enable` → `uninstall --yes` and a separate `uninstall --purge --yes`, asserting the preserve set, binary self-delete, bashrc surgery, and wrapper definition with/without the sentinel.