### PR TITLE
feat: shared registries — browse, import, contribute back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,21 @@ Three places must stay in step when a harness is added or changed:
 
 Add a `tests/shell_test.rs` case when changing `_akm_wrap_tool`.
 
+## Registries
+
+The personal registry (`registry.url`) is the only writable one and the only
+one that is mounted — it is checked out at `Paths::library_dir()` and *is* the
+cold library.
+
+Shared registries (`[shared]` in config) are read-only troves to import from.
+They are cloned into `Paths::shared_dir(name)` under the cache, are never
+symlinked into a tool dir, and never appear in `library.json`. Importing copies
+files into the personal library, where the copy becomes an ordinary spec.
+
+Keep it that way. Mounting a shared registry would put two sources into one flat
+namespace whose names are also the strings a model matches on, and would make
+drift, publish and revert per-registry — see issue #35 for the analysis.
+
 ## Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -219,17 +219,25 @@ library: nothing in it is ever mounted into a tool directory. You browse it,
 take what you want, and the copy becomes an ordinary skill of your own.
 
 ```bash
-akm config shared.acme git@github.com:acme/skills.git   # add one
-akm config shared.acme ""                                # remove it
+akm skills shared                # add/remove them from an interactive menu
+akm skills shared --plain         # or just list them (also the default when piped)
+
+akm config shared.acme git@github.com:acme/skills.git   # add one, scriptably
+akm config shared.acme ""                                # remove it, scriptably
 
 akm skills list acme              # what it offers, marking what you already have
 akm skills import acme tdd        # take one
 akm skills import acme --all      # take everything usable
 ```
 
+`akm skills shared` is the friendly front-end; `akm config shared.<name>` is the
+scriptable one. Both write the same config, so use whichever suits.
+
 Checkouts live in `$XDG_CACHE_HOME/akm/shared/<name>` and are refreshed by
-`akm skills sync` and by any of the commands above. A registry that cannot be
-reached is reported, and browsing falls back to the copy on disk.
+`akm skills sync` and by any of the commands above. Removing a registry deletes
+its checkout too — interactively at once, and otherwise on the next
+`akm skills sync`, which sweeps any checkout config no longer names. A registry
+that cannot be reached is reported, and browsing falls back to the copy on disk.
 
 Only directories holding a `SKILL.md` with a `name` and a `description` are
 importable; anything else is named and skipped. An id you already have is a

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ akm skills revert my-skill       # discard local changes (--remote: take the reg
 akm skills core                  # show core flags (--adopt / --publish to reconcile)
 akm skills promote ./my-skill     # import local skill to cold storage
 akm skills import <github-url>   # import skill from a GitHub URL
+akm skills list acme             # browse a shared registry
+akm skills import acme tdd       # take one skill from it (--all for everything)
+akm skills share acme my-skill   # offer one of yours back, as a pull request
 akm skills publish my-skill      # publish one spec to personal registry
 akm skills publish               # publish everything pending, in one commit
 akm skills clean --dry-run       # preview stale spec removal
@@ -201,6 +204,66 @@ akm skills import https://github.com/user/repo/tree/main/skills/my-skill --force
 ```
 
 Both `/tree/` (directory) and `/blob/` (file) GitHub URLs are supported. For private repos, set the `GITHUB_TOKEN` environment variable.
+
+`--all` takes every skill a URL offers instead of one:
+
+```bash
+akm skills import https://github.com/user/repo/tree/main/skills --all
+```
+
+#### Shared registries
+
+A shared registry is somebody else's skills repository — a team's, a
+colleague's, a community's. AKM treats it as a trove to pick from, not a second
+library: nothing in it is ever mounted into a tool directory. You browse it,
+take what you want, and the copy becomes an ordinary skill of your own.
+
+```bash
+akm config shared.acme git@github.com:acme/skills.git   # add one
+akm config shared.acme ""                                # remove it
+
+akm skills list acme              # what it offers, marking what you already have
+akm skills import acme tdd        # take one
+akm skills import acme --all      # take everything usable
+```
+
+Checkouts live in `$XDG_CACHE_HOME/akm/shared/<name>` and are refreshed by
+`akm skills sync` and by any of the commands above. A registry that cannot be
+reached is reported, and browsing falls back to the copy on disk.
+
+Only directories holding a `SKILL.md` with a `name` and a `description` are
+importable; anything else is named and skipped. An id you already have is a
+conflict, and interactively you choose per skill:
+
+```
+  tdd — already in your library, and it differs.
+    [m]ine  [t]heirs  [b]oth as 'acme-tdd'  (add 'a' for all):
+```
+
+`both` keeps yours and stores theirs under the prefixed id. Without a terminal,
+`--all` keeps yours and says so, while a single import fails unless you pass
+`--force`. Identical content is skipped silently, so re-running an import is a
+no-op until the registry actually moves.
+
+A registry's `core: true` is never inherited — that flag is its owner's
+statement about their machines. Imported skills land unmounted, and making one
+core here is `akm skills edit <id> --meta`.
+
+#### Contributing back
+
+```bash
+akm skills share acme my-skill
+```
+
+This pushes the spec to the shared registry on branch `akm/<id>` and relays the
+URL the remote prints for opening a pull request. Nothing is merged — the
+registry's owners decide. It needs permission to push a branch, not to write to
+the default branch, and re-running it updates the same branch so an open pull
+request follows along.
+
+`publish` and `share` are not the same act: `publish` writes to *your* registry
+on your own authority, while `share` offers a copy to someone else's and waits
+for their review.
 
 #### Publishing after promote or import
 
@@ -300,10 +363,16 @@ features = ["skills", "artifacts", "instructions"]
 
 [registry]
 url = "git@github.com:you/your-registry.git"
+
+[shared]
+acme = "git@github.com:acme/skills.git"
 ```
 
 `skills.personal_registry` is the pre-rc4 spelling of `registry.url` and still
 works; the canonical key wins when both are set.
+
+`[shared]` holds read-only registries to import from, one line per registry,
+named however you like. Set them with `akm config shared.<name> <git-url>`.
 
 On disk:
 
@@ -314,6 +383,9 @@ On disk:
   local.json        this machine's core deviations
   tools.json        harness definitions
   shell/            generated shell init
+
+~/.cache/akm/
+  shared/<name>/    checkout of a shared registry — browsable, never mounted
 ```
 
 ## How a session works

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -72,6 +72,10 @@ fn print_all(paths: &Paths, config: &Config) {
         config.registry_url().unwrap_or("(not set)")
     );
 
+    for (name, url) in &config.shared {
+        println!("  shared.{name:<19}= {url}");
+    }
+
     println!(
         "  artifacts.remote          = {}",
         config.artifacts.remote.as_deref().unwrap_or("(not set)")

--- a/src/commands/skills/import.rs
+++ b/src/commands/skills/import.rs
@@ -1,30 +1,67 @@
-//! `akm skills import` — import a remote skill from a GitHub URL into cold storage.
+//! `akm skills import` — copy a skill from elsewhere into cold storage.
 //!
-//! This is the remote counterpart to `promote`, which imports from local paths.
-//! Downloads the skill directory via the GitHub Contents API, validates it,
-//! runs interactive prompts, and copies to cold storage.
+//! Two address forms, one destination:
+//!
+//! - `import <url>` downloads a directory through the GitHub Contents API;
+//! - `import <remote> <id>` takes it from a configured shared registry, which
+//!   is a git checkout AKM already keeps in the cache.
+//!
+//! Either way the skill lands in the personal library as an ordinary spec. The
+//! only trace of where it came from is `source` in its sidecar: there is no
+//! lasting link, no upstream to track, and re-running the same import is how
+//! you take a later version.
+//!
+//! `core` is never inherited from a registry. Its `core: true` means "core on
+//! my machines", which is its owner's call about their own machines and nobody
+//! else's — so an imported skill lands unmounted and the choice stays local.
 
 use crate::commands::skills::promote::copy_dir_recursive;
 use crate::config::Config;
 use crate::error::{Error, IoContext, Result};
-use crate::github::{self, GitHubHttpClient};
+use crate::github::{self, GitHubClient, GitHubHttpClient, ParsedGitHubUrl};
 use crate::library::frontmatter::Frontmatter;
 use crate::library::libgen;
+use crate::library::spec::SpecMeta;
 use crate::library::symlinks;
 use crate::library::tool_dirs::ToolDirs;
 use crate::library::Library;
 use crate::paths::Paths;
 use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::Path;
 
-/// Run the `akm skills import` command.
-///
-/// # Arguments
-/// * `paths` — Resolved XDG paths
-/// * `config` — Loaded config, for the optional publish prompt
-/// * `url` — GitHub URL to a directory containing SKILL.md
-/// * `force` — Skip overwrite confirmation
-/// * `custom_id` — Optional override for the skill ID
-/// * `tool_dirs` — Tool directories for symlink rebuild
+use super::shared;
+
+/// What to do about an id that is already in the library.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Choice {
+    /// Keep what is already there; skip the incoming copy.
+    Mine,
+    /// Overwrite with the incoming copy.
+    Theirs,
+    /// Keep both — the incoming one is stored under a prefixed id.
+    Both,
+}
+
+/// How an incoming skill relates to what is already in the library.
+#[derive(Debug, PartialEq, Eq)]
+enum Standing {
+    /// Nothing of that id in the library.
+    Fresh,
+    /// Byte-identical to what is already there.
+    Same,
+    /// An id clash with different content.
+    Clash,
+}
+
+/// A choice the user asked to apply to every remaining conflict.
+#[derive(Default)]
+struct Sticky(Option<Choice>);
+
+/// Skills waiting to be installed: the id they arrived under, where their
+/// files are staged, and the metadata to write beside them.
+type Incoming = Vec<(String, std::path::PathBuf, SpecMeta)>;
+
+/// Run `akm skills import <url>` — one skill from a GitHub URL.
 pub fn run(
     paths: &Paths,
     config: &Config,
@@ -33,7 +70,6 @@ pub fn run(
     custom_id: Option<&str>,
     tool_dirs: &ToolDirs,
 ) -> Result<()> {
-    // Step 1: Parse the GitHub URL
     let parsed = github::parse_github_url(url)?;
     let id = match custom_id {
         Some(id) if !id.is_empty() => id.to_string(),
@@ -47,131 +83,495 @@ pub fn run(
     println!("  id:    {id}");
     println!();
 
-    // Step 2: Check overwrite BEFORE downloading (fail fast)
-    let library_dir = paths.library_dir();
-    let dest_path = library_dir.join("skills").join(&id);
-    let is_tty = io::stdin().is_terminal();
-
-    if dest_path.exists() && !force {
-        if is_tty {
-            print!("Skill '{id}' already exists in cold storage. Overwrite? [y/N]: ");
-            io::stdout().flush().ok();
-            let mut input = String::new();
-            io::stdin().lock().read_line(&mut input).ok();
-            if !input.trim().eq_ignore_ascii_case("y") {
-                println!("Aborted.");
-                return Ok(());
-            }
-        } else {
-            return Err(Error::SpecAlreadyExists { id });
-        }
-    }
-
-    // Step 3: Download to temp directory (atomic pattern)
-    // TempDir is dropped (and cleaned up) on all exit paths, including errors
-    let temp_dir = tempfile::tempdir().io_context("Creating temporary directory for import")?;
-
     let client = GitHubHttpClient::new();
-    let files = github::download_directory(&client, &parsed, temp_dir.path())?;
-
+    let staged = tempfile::tempdir().io_context("Creating temporary directory for import")?;
+    let files = github::download_directory(&client, &parsed, staged.path())?;
     if files.is_empty() {
         return Err(Error::ImportNoSkillMd {
             url: url.to_string(),
         });
     }
-
     println!("  Downloaded {} file(s)", files.len());
 
-    // Step 4: Validate SKILL.md exists and has valid frontmatter
-    let skill_md = temp_dir.path().join("SKILL.md");
+    let skill_md = staged.path().join("SKILL.md");
     if !skill_md.is_file() {
         return Err(Error::ImportNoSkillMd {
             url: url.to_string(),
         });
     }
-
     let fm = Frontmatter::parse_file(&skill_md)?;
     fm.require_name_and_description(&skill_md)?;
 
-    let name = fm.name.unwrap_or_else(|| id.clone());
-    let description = fm.description.unwrap_or_default();
-
-    // Step 5: Interactive prompts (TTY only) — mirrors promote.rs
-    let mut user_desc = description.clone();
-    let mut user_tags: Vec<String> = Vec::new();
-    let mut user_core = false;
-
-    if is_tty {
-        println!();
-        println!("Importing skill:");
-        println!("  id:     {id}");
-        println!("  name:   {name}");
-        println!("  source: {}", parsed.browsable_url());
-        println!();
-
-        print!("  Description [{description}]: ");
-        io::stdout().flush().ok();
-        let mut input = String::new();
-        io::stdin().lock().read_line(&mut input).ok();
-        let input = input.trim();
-        if !input.is_empty() {
-            user_desc = input.to_string();
-        }
-
-        print!("  Tags (comma-separated) []: ");
-        io::stdout().flush().ok();
-        let mut input = String::new();
-        io::stdin().lock().read_line(&mut input).ok();
-        let input = input.trim();
-        if !input.is_empty() {
-            user_tags = input
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-
-        print!("  Core skill (always available globally)? [y/N]: ");
-        io::stdout().flush().ok();
-        let mut input = String::new();
-        io::stdin().lock().read_line(&mut input).ok();
-        user_core = input.trim().eq_ignore_ascii_case("y");
-
-        println!();
-    }
-
-    // Step 6: Copy to cold storage (from temp dir, not directly from GitHub)
-    if dest_path.exists() {
-        std::fs::remove_dir_all(&dest_path).io_context(format!(
-            "Removing existing skill at {}",
-            dest_path.display()
-        ))?;
-    }
-    copy_dir_recursive(temp_dir.path(), &dest_path)?;
-    println!("  Copied skill to cold storage");
-
-    // Step 7: Record the metadata the user typed, plus where the skill came
-    // from, in the spec's sidecar — then derive library.json from it.
-    super::promote::write_sidecar(
+    let library_dir = paths.library_dir();
+    let mut sticky = Sticky::default();
+    let resolved = match settle(
         &library_dir,
         &id,
-        user_desc,
-        user_tags,
-        user_core,
-        Some(parsed.browsable_url()),
-    )?;
-    libgen::generate(&library_dir, &paths.library_json())?;
-    let library = Library::load_from(&paths.library_json())?;
+        staged.path(),
+        &parsed.owner,
+        force,
+        false,
+        &mut sticky,
+    )? {
+        Some(id) => id,
+        None => {
+            println!("Aborted.");
+            return Ok(());
+        }
+    };
 
-    // Step 9: Rebuild global symlinks
-    let core_specs = library.core_specs();
-    let count = symlinks::rebuild_core(&core_specs, &library_dir, tool_dirs.dirs())?;
-    println!("  {count} core symlinks rebuilt");
+    let meta = prompted_meta(&id, &fm, Some(parsed.browsable_url()));
+    install(&library_dir, &resolved, staged.path(), meta)?;
+    println!("  Copied skill to cold storage");
+
+    rebuild(paths, tool_dirs, &library_dir)?;
     println!();
-    println!("Imported skill '{id}' from GitHub");
+    println!("Imported skill '{resolved}' from GitHub");
 
-    // Step 10: Offer to publish to the personal registry
-    super::publish::offer(paths, config, &id);
+    super::publish::offer(paths, config, &resolved);
+    Ok(())
+}
+
+/// Run `akm skills import <remote> <id>` — one skill from a shared registry.
+pub fn run_remote(
+    paths: &Paths,
+    config: &Config,
+    remote: &str,
+    id: &str,
+    force: bool,
+    custom_id: Option<&str>,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let registry = shared::open(paths, config, remote)?;
+    println!("Refreshing '{remote}' ({})...", registry.url());
+    shared::refresh_for_use(&registry)?;
+
+    let catalogue = shared::catalogue(registry.dir())?;
+    let candidate = catalogue
+        .get(id)
+        .ok_or_else(|| Error::SpecNotFound { id: id.to_string() })?;
+
+    let stored_as = custom_id.filter(|id| !id.is_empty()).unwrap_or(id);
+    let library_dir = paths.library_dir();
+    let mut sticky = Sticky::default();
+
+    let resolved = match settle(
+        &library_dir,
+        stored_as,
+        &candidate.dir,
+        remote,
+        force,
+        false,
+        &mut sticky,
+    )? {
+        Some(id) => id,
+        None => {
+            println!("Kept your own '{stored_as}' — nothing was imported.");
+            return Ok(());
+        }
+    };
+
+    let meta = source_meta(&candidate.meta, remote, registry.url());
+    let was_core = candidate.meta.core;
+    install(&library_dir, &resolved, &candidate.dir, meta)?;
+    rebuild(paths, tool_dirs, &library_dir)?;
+
+    println!("Imported skill '{resolved}' from '{remote}'");
+    if was_core {
+        println!("  ('{remote}' marks it core; run 'akm skills edit {resolved} --meta' to do the same here)");
+    }
+
+    super::publish::offer(paths, config, &resolved);
+    Ok(())
+}
+
+/// Run `akm skills import <remote> --all` — every valid skill in a registry.
+pub fn run_all_remote(
+    paths: &Paths,
+    config: &Config,
+    remote: &str,
+    force: bool,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let registry = shared::open(paths, config, remote)?;
+    println!("Refreshing '{remote}' ({})...", registry.url());
+    shared::refresh_for_use(&registry)?;
+
+    let catalogue = shared::catalogue(registry.dir())?;
+    report_skipped(&catalogue.skipped);
+
+    let url = registry.url().to_string();
+    let incoming: Incoming = catalogue
+        .skills
+        .iter()
+        .map(|c| {
+            (
+                c.id.clone(),
+                c.dir.clone(),
+                source_meta(&c.meta, remote, &url),
+            )
+        })
+        .collect();
+
+    import_many(paths, config, remote, incoming, force, tool_dirs)
+}
+
+/// Run `akm skills import <url> --all` — every valid skill under a GitHub path.
+///
+/// Each subdirectory is listed before anything is downloaded, so a repository
+/// holding a dozen non-skill directories costs a dozen cheap listings rather
+/// than a dozen full downloads.
+pub fn run_all_url(
+    paths: &Paths,
+    config: &Config,
+    url: &str,
+    force: bool,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let parsed = github::parse_github_url(url)?;
+    let client = GitHubHttpClient::new();
+
+    println!(
+        "Scanning {}/{} at {}...",
+        parsed.owner, parsed.repo, parsed.path
+    );
+
+    let staged = tempfile::tempdir().io_context("Creating temporary directory for import")?;
+    let (incoming, skipped) = download_all(&client, &parsed, staged.path())?;
+    report_skipped(&skipped);
+
+    import_many(paths, config, &parsed.owner, incoming, force, tool_dirs)
+}
+
+/// Download every subdirectory that holds a usable `SKILL.md`.
+fn download_all(
+    client: &dyn GitHubClient,
+    parsed: &ParsedGitHubUrl,
+    staged: &Path,
+) -> Result<(Incoming, Vec<shared::Skipped>)> {
+    let mut incoming = Vec::new();
+    let mut skipped = Vec::new();
+
+    let mut entries = client.list_contents(parsed, "")?;
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for entry in entries.iter().filter(|e| e.entry_type == "dir") {
+        let child = ParsedGitHubUrl {
+            path: entry.path.clone(),
+            ..parsed.clone()
+        };
+
+        let contents = client.list_contents(&child, "")?;
+        if !contents.iter().any(|e| e.name == "SKILL.md") {
+            skipped.push(shared::Skipped {
+                id: entry.name.clone(),
+                reason: "no SKILL.md".into(),
+            });
+            continue;
+        }
+
+        let dest = staged.join(&entry.name);
+        std::fs::create_dir_all(&dest)
+            .io_context(format!("Creating staging dir {}", dest.display()))?;
+        github::download_directory(client, &child, &dest)?;
+
+        let skill_md = dest.join("SKILL.md");
+        let fm = match Frontmatter::parse_file(&skill_md)
+            .and_then(|fm| fm.require_name_and_description(&skill_md).map(|()| fm))
+        {
+            Ok(fm) => fm,
+            Err(e) => {
+                skipped.push(shared::Skipped {
+                    id: entry.name.clone(),
+                    reason: format!("{e}").replace('\n', " "),
+                });
+                continue;
+            }
+        };
+
+        let mut meta = SpecMeta::from_frontmatter(&entry.name, &fm);
+        meta.source = Some(child.browsable_url());
+        incoming.push((entry.name.clone(), dest, meta));
+    }
+
+    Ok((incoming, skipped))
+}
+
+/// Import a batch, resolving each id clash as it comes.
+fn import_many(
+    paths: &Paths,
+    config: &Config,
+    prefix: &str,
+    incoming: Incoming,
+    force: bool,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let library_dir = paths.library_dir();
+    let mut sticky = Sticky::default();
+    let mut imported: Vec<String> = Vec::new();
+    let mut unchanged = 0usize;
+    let mut kept_mine: Vec<String> = Vec::new();
+
+    let fresh = incoming
+        .iter()
+        .filter(|(id, dir, _)| {
+            standing(&library_dir.join("skills").join(id), dir) == Standing::Fresh
+        })
+        .count();
+    println!();
+    println!(
+        "{} skill(s) available: {fresh} new, {} already in your library",
+        incoming.len(),
+        incoming.len() - fresh
+    );
+    println!();
+
+    for (id, dir, meta) in &incoming {
+        match settle(&library_dir, id, dir, prefix, force, true, &mut sticky)? {
+            Some(resolved) => {
+                install(&library_dir, &resolved, dir, meta.clone())?;
+                imported.push(resolved);
+            }
+            None if standing(&library_dir.join("skills").join(id), dir) == Standing::Same => {
+                unchanged += 1;
+            }
+            None => kept_mine.push(id.clone()),
+        }
+    }
+
+    if imported.is_empty() {
+        println!("Nothing imported.");
+        return Ok(());
+    }
+
+    rebuild(paths, tool_dirs, &library_dir)?;
+
+    println!();
+    println!("Imported {} skill(s):", imported.len());
+    for id in &imported {
+        println!("  {id}");
+    }
+    if unchanged > 0 {
+        println!("{unchanged} already up to date.");
+    }
+    if !kept_mine.is_empty() {
+        println!("Kept your own: {}", kept_mine.join(", "));
+    }
+
+    if config.registry_url().is_some() {
+        println!();
+        println!("Publish them to your registry with 'akm skills publish'.");
+    }
 
     Ok(())
+}
+
+/// Decide the id an incoming skill lands under, or `None` to skip it.
+///
+/// Identical content is skipped without asking: re-running an import must be
+/// a no-op, or `--all` becomes a wall of prompts about skills that have not
+/// moved. `--force` answers every clash with "theirs", which is what it has
+/// always meant here.
+fn settle(
+    library_dir: &Path,
+    id: &str,
+    incoming: &Path,
+    prefix: &str,
+    force: bool,
+    batch: bool,
+    sticky: &mut Sticky,
+) -> Result<Option<String>> {
+    let dest = library_dir.join("skills").join(id);
+
+    match standing(&dest, incoming) {
+        Standing::Fresh => return Ok(Some(id.to_string())),
+        Standing::Same => return Ok(None),
+        Standing::Clash => {}
+    }
+
+    if force {
+        return Ok(Some(id.to_string()));
+    }
+
+    // No terminal to ask. A single import fails, the way it always has, so a
+    // script gets an exit code; a batch skips the clash and keeps going, since
+    // one contested id must not cost the other eleven.
+    if !io::stdin().is_terminal() {
+        if !batch {
+            return Err(Error::SpecAlreadyExists { id: id.to_string() });
+        }
+        println!("  {id}: already in your library, kept yours (no terminal to ask)");
+        return Ok(None);
+    }
+
+    let choice = match sticky.0 {
+        Some(choice) => choice,
+        None => ask(id, prefix, sticky)?,
+    };
+
+    match choice {
+        Choice::Mine => Ok(None),
+        Choice::Theirs => Ok(Some(id.to_string())),
+        Choice::Both => {
+            let prefixed = format!("{prefix}-{id}");
+            if library_dir.join("skills").join(&prefixed).exists() {
+                return Err(Error::SpecAlreadyExists { id: prefixed });
+            }
+            Ok(Some(prefixed))
+        }
+    }
+}
+
+/// Prompt for one clash.
+fn ask(id: &str, prefix: &str, sticky: &mut Sticky) -> Result<Choice> {
+    loop {
+        println!("  {id} — already in your library, and it differs.");
+        print!("    [m]ine  [t]heirs  [b]oth as '{prefix}-{id}'  (add 'a' for all): ");
+        io::stdout().flush().ok();
+
+        let mut input = String::new();
+        io::stdin().lock().read_line(&mut input).ok();
+        let input = input.trim().to_lowercase();
+        let all = input.ends_with('a') && input.len() > 1;
+
+        let choice = match input.chars().next() {
+            Some('m') => Choice::Mine,
+            Some('t') => Choice::Theirs,
+            Some('b') => Choice::Both,
+            _ => {
+                println!("    Please answer m, t or b.");
+                continue;
+            }
+        };
+
+        if all {
+            sticky.0 = Some(choice);
+        }
+        return Ok(choice);
+    }
+}
+
+/// Where an incoming skill stands relative to the library.
+fn standing(dest: &Path, incoming: &Path) -> Standing {
+    if !dest.exists() {
+        Standing::Fresh
+    } else if same_tree(dest, incoming) {
+        Standing::Same
+    } else {
+        Standing::Clash
+    }
+}
+
+/// Whether two directory trees hold the same files with the same bytes.
+///
+/// The sidecar is excluded: it carries `source`, which the import itself
+/// writes, so comparing it would make every imported skill look changed the
+/// moment it landed.
+fn same_tree(a: &Path, b: &Path) -> bool {
+    let (mut left, mut right) = (Vec::new(), Vec::new());
+    if collect(a, a, &mut left).is_err() || collect(b, b, &mut right).is_err() {
+        return false;
+    }
+    left.sort();
+    right.sort();
+
+    if left != right {
+        return false;
+    }
+
+    left.iter().all(
+        |rel| match (std::fs::read(a.join(rel)), std::fs::read(b.join(rel))) {
+            (Ok(x), Ok(y)) => x == y,
+            _ => false,
+        },
+    )
+}
+
+/// Relative paths of every file under `dir`, ignoring the metadata sidecar.
+fn collect(root: &Path, dir: &Path, out: &mut Vec<std::path::PathBuf>) -> Result<()> {
+    for entry in std::fs::read_dir(dir).io_context(format!("Reading {}", dir.display()))? {
+        let path = entry.io_context("Reading directory entry")?.path();
+        if path.is_dir() {
+            collect(root, &path, out)?;
+        } else if path.file_name().map(|n| n != "akm.json").unwrap_or(false) {
+            if let Ok(rel) = path.strip_prefix(root) {
+                out.push(rel.to_path_buf());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Copy an incoming skill into the library and write its sidecar.
+fn install(library_dir: &Path, id: &str, src: &Path, meta: SpecMeta) -> Result<()> {
+    let dest = library_dir.join("skills").join(id);
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest)
+            .io_context(format!("Removing existing skill at {}", dest.display()))?;
+    }
+    copy_dir_recursive(src, &dest)?;
+    meta.save_to(&crate::library::spec::SpecType::Skill.sidecar_path(library_dir, id))
+}
+
+/// Metadata for a skill taken from a shared registry.
+fn source_meta(meta: &SpecMeta, remote: &str, url: &str) -> SpecMeta {
+    let mut meta = meta.clone();
+    meta.source = Some(format!("{remote} ({url})"));
+    // Core is a local decision — see the module docs.
+    meta.core = false;
+    meta
+}
+
+/// Ask for the metadata an interactive URL import has always asked for.
+fn prompted_meta(id: &str, fm: &Frontmatter, source: Option<String>) -> SpecMeta {
+    let mut meta = SpecMeta::from_frontmatter(id, fm);
+    meta.source = source;
+
+    if !io::stdin().is_terminal() {
+        return meta;
+    }
+
+    print!("  Description [{}]: ", meta.description);
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    if !input.trim().is_empty() {
+        meta.description = input.trim().to_string();
+    }
+
+    print!("  Tags (comma-separated) []: ");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    meta.tags = input
+        .trim()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    print!("  Core skill (always available globally)? [y/N]: ");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    meta.core = input.trim().eq_ignore_ascii_case("y");
+
+    println!();
+    meta
+}
+
+/// Regenerate the index and the global symlinks after an import.
+fn rebuild(paths: &Paths, tool_dirs: &ToolDirs, library_dir: &Path) -> Result<()> {
+    libgen::generate(library_dir, &paths.library_json())?;
+    let library = Library::load_from(&paths.library_json())?;
+    let count = symlinks::rebuild_core(&library.core_specs(), library_dir, tool_dirs.dirs())?;
+    println!("  {count} core symlinks rebuilt");
+    Ok(())
+}
+
+/// Name the directories that looked like skills but could not be imported.
+fn report_skipped(skipped: &[shared::Skipped]) {
+    for entry in skipped {
+        println!("  skipped {}: {}", entry.id, entry.reason);
+    }
 }

--- a/src/commands/skills/list.rs
+++ b/src/commands/skills/list.rs
@@ -3,12 +3,15 @@
 //! In Task 4 this was plain-only. Task 9 adds TUI as the default mode
 //! when stdout is a TTY and --plain is not passed.
 
+use crate::config::Config;
 use crate::error::Result;
 use crate::library::spec::SpecType;
 use crate::library::tool_dirs::ToolDirs;
 use crate::library::Library;
 use crate::paths::Paths;
 use std::io::IsTerminal;
+
+use super::shared;
 
 /// Determine whether to use TUI or plain output.
 ///
@@ -39,6 +42,46 @@ pub fn run(
     } else {
         run_plain(paths, tag, parsed_type)
     }
+}
+
+/// Run `akm skills list <remote>` — browse a shared registry.
+///
+/// Plain output only: there is nothing to drive a TUI with here. A shared
+/// registry has no drift, no core state and no project manifest — the only
+/// question it answers is what it holds and whether you already have it.
+pub fn run_shared(paths: &Paths, config: &Config, remote: &str) -> Result<()> {
+    let registry = shared::open(paths, config, remote)?;
+    let outcome = shared::refresh_for_use(&registry)?;
+    println!("{remote} ({}) — {outcome}", registry.url());
+    println!();
+
+    let catalogue = shared::catalogue(registry.dir())?;
+    let library = Library::load_or_default(&paths.library_json())?;
+    let library_dir = paths.library_dir();
+
+    for candidate in &catalogue.skills {
+        let mark = match library.get(&candidate.id) {
+            Some(spec) if spec.exists_on_disk(&library_dir) => "  [have]",
+            _ => "",
+        };
+        println!(
+            "  {:<35} {}{mark}",
+            candidate.id, candidate.meta.description
+        );
+    }
+
+    if catalogue.skills.is_empty() {
+        println!("  (no importable skills)");
+    }
+
+    for entry in &catalogue.skipped {
+        println!("  {:<35} (skipped: {})", entry.id, entry.reason);
+    }
+
+    println!();
+    println!("Import one with 'akm skills import {remote} <id>', or all of them with --all.");
+
+    Ok(())
 }
 
 /// Plain output mode — identical to Task 4 implementation.

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -19,5 +19,7 @@ pub mod rename;
 pub mod revert;
 pub mod search;
 pub mod session_setup;
+pub mod share;
+pub mod shared;
 pub mod status;
 pub mod sync;

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -21,5 +21,6 @@ pub mod search;
 pub mod session_setup;
 pub mod share;
 pub mod shared;
+pub mod shared_menu;
 pub mod status;
 pub mod sync;

--- a/src/commands/skills/share.rs
+++ b/src/commands/skills/share.rs
@@ -1,0 +1,114 @@
+//! `akm skills share <remote> <id>` — offer one of your specs to a shared registry.
+//!
+//! Distinct from `publish`, which pushes to *your* registry, on your own
+//! authority. A shared registry belongs to someone else, so a contribution is a
+//! branch and a request, and whoever owns the registry decides. AKM pushes the
+//! branch and stops there.
+//!
+//! The push is deliberately all AKM does about the pull request. Git's own
+//! output already carries the URL for opening one — GitHub, GitLab, Gitea and
+//! Bitbucket all print it on a first push — so relaying that verbatim works on
+//! every forge and needs no API token.
+
+use crate::config::Config;
+use crate::error::{Error, IoContext, Result};
+use crate::library::spec::Spec;
+use crate::library::Library;
+use crate::paths::Paths;
+use crate::registry::Registry;
+use std::path::Path;
+
+/// Run the `akm skills share` command.
+pub fn run(paths: &Paths, config: &Config, remote: &str, id: &str, dry_run: bool) -> Result<()> {
+    let url = config.shared_remote(remote)?;
+
+    let library_dir = paths.library_dir();
+    let library = Library::load_checked(paths)?;
+    let spec = library
+        .get(id)
+        .ok_or_else(|| Error::SpecNotFound { id: id.to_string() })?;
+
+    if !spec.exists_on_disk(&library_dir) {
+        return Err(Error::SpecNotFound { id: id.to_string() });
+    }
+
+    let branch = format!("akm/{id}");
+
+    println!("Sharing {} '{id}' with '{remote}':", spec.spec_type);
+    println!("  remote: {url}");
+    println!("  branch: {branch}");
+    println!();
+
+    if dry_run {
+        println!("Dry run — nothing was pushed.");
+        return Ok(());
+    }
+
+    // A throwaway clone, not the cached checkout: sharing must never leave the
+    // browsable copy of a shared registry parked on a contribution branch.
+    let tmp = tempfile::tempdir().io_context("Creating a temporary directory for the clone")?;
+    let staging = Registry::named(remote, url, tmp.path().join("registry"));
+    staging.clone_fresh()?;
+    println!("  Cloned {remote}");
+
+    staging.checkout_contribution_branch(&branch)?;
+    copy_spec(spec, &library_dir, staging.dir())?;
+
+    let message = format!("feat: add {} '{id}'", spec.spec_type);
+    match staging.push_contribution(&branch, &spec.pathspecs(), &message)? {
+        None => {
+            println!();
+            println!(
+                "Nothing to share — '{remote}' already has this exact {}.",
+                spec.spec_type
+            );
+        }
+        Some(hint) => {
+            println!("  Committed: {message}");
+            println!("  Pushed branch {branch}");
+            if !hint.is_empty() {
+                println!();
+                println!("{hint}");
+            }
+            println!();
+            println!("Open a pull request on '{remote}' to finish sharing '{id}'.");
+        }
+    }
+
+    Ok(())
+}
+
+/// Copy every file belonging to a spec into the staging checkout.
+///
+/// Driven by the spec's own pathspecs, so an agent's markdown and its sidecar
+/// travel together and a skill's whole directory goes as one — the same unit
+/// git operates on everywhere else.
+fn copy_spec(spec: &Spec, library_dir: &Path, dest_root: &Path) -> Result<()> {
+    for rel in spec.pathspecs() {
+        let src = library_dir.join(&rel);
+        let dest = dest_root.join(&rel);
+
+        if src.is_dir() {
+            // The remote may already have an older copy; replacing it wholesale
+            // is what makes a re-share a clean update rather than a merge of
+            // two file sets.
+            if dest.exists() {
+                std::fs::remove_dir_all(&dest)
+                    .io_context(format!("Removing {} before copying", dest.display()))?;
+            }
+            super::promote::copy_dir_recursive(&src, &dest)?;
+        } else if src.is_file() {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)
+                    .io_context(format!("Creating {}", parent.display()))?;
+            }
+            std::fs::copy(&src, &dest).io_context(format!(
+                "Copying {} to {}",
+                src.display(),
+                dest.display()
+            ))?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/skills/shared.rs
+++ b/src/commands/skills/shared.rs
@@ -217,6 +217,47 @@ pub fn refresh_all(paths: &Paths, config: &Config) -> Vec<(String, RefreshOutcom
         .collect()
 }
 
+/// Delete cached checkouts of shared registries that config no longer names.
+///
+/// The scriptable removal path (`akm config shared.<name> ""`) drops the config
+/// entry but cannot touch the cache — [`crate::config::ConfigKey::set`] has only
+/// a `&mut Config`, no `Paths`. Sync reconciles the two: any subdirectory under
+/// [`Paths::shared_root`] whose name is not a live, non-empty entry in
+/// `config.shared` is an orphaned checkout, safe to delete because the whole
+/// tree is reconstructible from its remote.
+///
+/// Best-effort and idempotent: a failed delete or an absent root is a no-op, and
+/// a second sweep finds nothing. Returns the names it removed, sorted, for the
+/// sync report.
+pub fn sweep_orphans(paths: &Paths, config: &Config) -> Vec<String> {
+    let live: std::collections::HashSet<&str> = config
+        .shared
+        .iter()
+        .filter(|(_, url)| !url.is_empty())
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    // A missing root is the normal empty case — nothing was ever cloned.
+    let entries = match std::fs::read_dir(paths.shared_root()) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut swept = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !live.contains(name.as_str()) {
+            std::fs::remove_dir_all(entry.path()).ok();
+            swept.push(name);
+        }
+    }
+    swept.sort();
+    swept
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,5 +319,50 @@ mod tests {
     fn a_checkout_without_skills_is_not_a_registry() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(catalogue(tmp.path()).is_err());
+    }
+
+    fn paths_under(root: &Path) -> Paths {
+        Paths::from_roots(
+            &root.join("data"),
+            &root.join("config"),
+            &root.join("cache"),
+            &root.join("home"),
+        )
+    }
+
+    #[test]
+    fn sweep_orphans_deletes_only_unconfigured_checkouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_under(tmp.path());
+
+        // Three checkouts sit in the cache...
+        for name in ["keep", "gone", "also-gone"] {
+            std::fs::create_dir_all(paths.shared_dir(name)).unwrap();
+        }
+
+        // ...but only one is a live entry. `also-gone` is configured with an
+        // empty URL, which counts as removed — same as `refresh_all`.
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("keep".into(), "git@example.com:keep.git".into());
+        config.shared.insert("also-gone".into(), String::new());
+
+        let swept = sweep_orphans(&paths, &config);
+
+        assert_eq!(swept, vec!["also-gone".to_string(), "gone".to_string()]);
+        assert!(paths.shared_dir("keep").is_dir());
+        assert!(!paths.shared_dir("gone").exists());
+        assert!(!paths.shared_dir("also-gone").exists());
+
+        // Idempotent — a second sweep finds nothing.
+        assert!(sweep_orphans(&paths, &config).is_empty());
+    }
+
+    #[test]
+    fn sweep_orphans_is_a_noop_when_nothing_was_ever_cloned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_under(tmp.path());
+        assert!(sweep_orphans(&paths, &Config::default()).is_empty());
     }
 }

--- a/src/commands/skills/shared.rs
+++ b/src/commands/skills/shared.rs
@@ -1,0 +1,282 @@
+//! Shared registries — read-only troves to browse and import from.
+//!
+//! A shared registry is somebody else's skills repository: a colleague's, a
+//! team's, a community's. AKM never mounts anything from one. It clones it,
+//! lets you look, and copies what you pick into your personal library, where
+//! the copy becomes an ordinary personal spec with no lasting tie to its
+//! source beyond the `source` field in its sidecar.
+//!
+//! That restraint is the whole design. Mounting two registries at once would
+//! force a precedence rule into the one namespace whose names are also the
+//! strings a model matches on, and would make drift, publish and revert
+//! per-registry. Importing instead leaves every one of those exactly as it was.
+//!
+//! The checkout lives in the cache ([`Paths::shared_dir`]) because it is
+//! reconstructible from its remote and owned by nobody here.
+
+use crate::config::Config;
+use crate::error::{Error, IoContext, Result};
+use crate::library::libgen;
+use crate::library::spec::{SpecMeta, SpecType};
+use crate::paths::Paths;
+use crate::registry::{Registry, SyncOutcome};
+use std::path::{Path, PathBuf};
+
+/// What refreshing a shared registry's checkout did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// First contact — the registry was cloned.
+    Cloned,
+    /// Already level with the remote.
+    UpToDate,
+    /// Fast-forwarded to the remote.
+    Updated,
+    /// Could not reach the remote. Whatever is on disk is still usable.
+    Failed { message: String },
+}
+
+impl std::fmt::Display for RefreshOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefreshOutcome::Cloned => write!(f, "cloned"),
+            RefreshOutcome::UpToDate => write!(f, "up to date"),
+            RefreshOutcome::Updated => write!(f, "updated"),
+            RefreshOutcome::Failed { message } => write!(f, "unreachable ({message})"),
+        }
+    }
+}
+
+/// One importable skill found in a shared registry.
+pub struct Candidate {
+    /// Directory name under `skills/`, and the id it would be imported under.
+    pub id: String,
+    /// Absolute path to the skill's directory in the checkout.
+    pub dir: PathBuf,
+    /// Metadata from the skill's sidecar, or its frontmatter when it has none.
+    pub meta: SpecMeta,
+}
+
+/// A directory that could not be imported, and why.
+pub struct Skipped {
+    pub id: String,
+    pub reason: String,
+}
+
+/// Everything a shared registry offers, plus what it offered that was unusable.
+pub struct Catalogue {
+    pub skills: Vec<Candidate>,
+    pub skipped: Vec<Skipped>,
+}
+
+impl Catalogue {
+    /// Look up one candidate by id.
+    pub fn get(&self, id: &str) -> Option<&Candidate> {
+        self.skills.iter().find(|c| c.id == id)
+    }
+}
+
+/// Open a handle to a configured shared registry. Does not touch the network.
+pub fn open(paths: &Paths, config: &Config, name: &str) -> Result<Registry> {
+    let url = config.shared_remote(name)?;
+    Ok(Registry::named(name, url, paths.shared_dir(name)))
+}
+
+/// Clone the registry, or fast-forward the checkout that is already there.
+///
+/// Never fatal on its own: a registry that cannot be reached leaves the
+/// previous checkout in place, so browsing and importing keep working offline.
+/// Callers that need content check [`Registry::is_cloned`] afterwards.
+pub fn refresh(registry: &Registry) -> RefreshOutcome {
+    if !registry.is_cloned() {
+        return match registry.clone_fresh() {
+            Ok(()) => RefreshOutcome::Cloned,
+            Err(e) => RefreshOutcome::Failed {
+                message: one_line(&e, registry.name()),
+            },
+        };
+    }
+
+    match registry.update() {
+        Ok(SyncOutcome::UpToDate) => RefreshOutcome::UpToDate,
+        Ok(_) => RefreshOutcome::Updated,
+        Err(e) => RefreshOutcome::Failed {
+            message: one_line(&e, registry.name()),
+        },
+    }
+}
+
+/// Reduce a failure to something that fits in a one-line report.
+///
+/// Git answers a failed fetch with a paragraph, and this string is printed
+/// mid-sentence in `akm skills sync`'s registry list. The first line carries
+/// which operation failed; the rest is advice about SSH keys that belongs to
+/// whoever goes looking. The registry's own name is stripped because the line
+/// it lands in already starts with it.
+fn one_line(error: &Error, name: &str) -> String {
+    let text = format!("{error}");
+    let first = text.lines().next().unwrap_or_default();
+    first
+        .strip_prefix(&format!("Failed to sync registry '{name}': "))
+        .unwrap_or(first)
+        .trim()
+        .to_string()
+}
+
+/// Refresh a registry and fail if that left nothing to read.
+///
+/// The distinction matters: `akm skills sync` reports an unreachable registry
+/// and moves on, while `list` and `import` have nothing to do without content.
+pub fn refresh_for_use(registry: &Registry) -> Result<RefreshOutcome> {
+    let outcome = refresh(registry);
+    if !registry.is_cloned() {
+        if let RefreshOutcome::Failed { message } = &outcome {
+            return Err(Error::RegistrySync {
+                name: registry.name().to_string(),
+                message: message.clone(),
+            });
+        }
+    }
+    Ok(outcome)
+}
+
+/// Scan a checkout for importable skills.
+///
+/// Validity is deliberately strict and reported rather than silent: a shared
+/// registry is written by someone else, and a directory that looks like a skill
+/// but has no `SKILL.md`, or frontmatter missing the two fields every harness
+/// needs, would otherwise be imported as something that never activates.
+///
+/// Skills only — same as `import` and `promote`, which have never handled
+/// agents either.
+pub fn catalogue(dir: &Path) -> Result<Catalogue> {
+    let skills_dir = dir.join("skills");
+    if !skills_dir.is_dir() {
+        return Err(Error::NoSpecDirs {
+            path: dir.to_path_buf(),
+        });
+    }
+
+    let mut entries: Vec<_> = std::fs::read_dir(&skills_dir)
+        .io_context(format!("Reading skills directory {}", skills_dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().is_dir())
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut skills = Vec::new();
+    let mut skipped = Vec::new();
+
+    for entry in entries {
+        let id = entry.file_name().to_string_lossy().to_string();
+        let spec_dir = entry.path();
+        let md_file = spec_dir.join("SKILL.md");
+
+        if !md_file.is_file() {
+            skipped.push(Skipped {
+                id,
+                reason: "no SKILL.md".into(),
+            });
+            continue;
+        }
+
+        match crate::library::frontmatter::Frontmatter::parse_file(&md_file)
+            .and_then(|fm| fm.require_name_and_description(&md_file))
+        {
+            Ok(()) => skills.push(Candidate {
+                meta: libgen::resolve_meta(dir, &id, SpecType::Skill, &md_file),
+                id,
+                dir: spec_dir,
+            }),
+            Err(e) => skipped.push(Skipped {
+                id,
+                reason: format!("{e}").replace('\n', " "),
+            }),
+        }
+    }
+
+    Ok(Catalogue { skills, skipped })
+}
+
+/// Refresh every configured shared registry, reporting each one.
+///
+/// One unreachable registry never stops the others: the report carries its
+/// failure and the loop continues.
+pub fn refresh_all(paths: &Paths, config: &Config) -> Vec<(String, RefreshOutcome, usize)> {
+    config
+        .shared
+        .iter()
+        .filter(|(_, url)| !url.is_empty())
+        .map(|(name, url)| {
+            let registry = Registry::named(name, url, paths.shared_dir(name));
+            let outcome = refresh(&registry);
+            let count = catalogue(registry.dir())
+                .map(|c| c.skills.len())
+                .unwrap_or(0);
+            (name.clone(), outcome, count)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn catalogue_reports_why_a_directory_was_unusable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write(
+            &root.join("skills/good/SKILL.md"),
+            "---\nname: good\ndescription: a real skill\n---\nbody\n",
+        );
+        write(
+            &root.join("skills/no-description/SKILL.md"),
+            "---\nname: no-description\n---\nbody\n",
+        );
+        write(&root.join("skills/notes/README.md"), "not a skill\n");
+
+        let catalogue = catalogue(root).unwrap();
+
+        let ids: Vec<&str> = catalogue.skills.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["good"]);
+        assert_eq!(catalogue.skills[0].meta.description, "a real skill");
+
+        let skipped: Vec<(&str, bool)> = catalogue
+            .skipped
+            .iter()
+            .map(|s| (s.id.as_str(), s.reason.contains("SKILL.md")))
+            .collect();
+        assert_eq!(skipped, vec![("no-description", true), ("notes", true)]);
+    }
+
+    #[test]
+    fn catalogue_prefers_the_sidecar_over_the_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write(
+            &root.join("skills/tdd/SKILL.md"),
+            "---\nname: tdd\ndescription: llm-facing trigger\n---\nbody\n",
+        );
+        write(
+            &root.join("skills/tdd/akm.json"),
+            r#"{"name":"TDD","description":"human-facing prose","tags":["testing"],"core":false}"#,
+        );
+
+        let catalogue = catalogue(root).unwrap();
+        assert_eq!(catalogue.skills[0].meta.description, "human-facing prose");
+        assert_eq!(catalogue.skills[0].meta.tags, vec!["testing"]);
+    }
+
+    #[test]
+    fn a_checkout_without_skills_is_not_a_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(catalogue(tmp.path()).is_err());
+    }
+}

--- a/src/commands/skills/shared_menu.rs
+++ b/src/commands/skills/shared_menu.rs
@@ -1,0 +1,447 @@
+//! `akm skills shared` — interactively manage shared registries.
+//!
+//! Shared registries are named git URLs (`[shared]` in config) that you browse
+//! and import from. The scriptable way to manage them is `akm config
+//! shared.<name> <url>`; this command is the human-facing front-end over the
+//! same config, so both an agent and a person can drive AKM.
+//!
+//! On a terminal it loops a small add/remove menu. Piped, redirected, or with
+//! `--plain`, it prints the list and exits — the read path for agents and the
+//! "just show me what's configured" path for people.
+//!
+//! Writes still go through `config.save`; nothing here is a second source of
+//! truth. Removal also drops the cached checkout, matching the sweep that
+//! `akm skills sync` does for the scriptable removal path.
+
+use crate::config::{is_valid_shared_name, Config};
+use crate::error::{Error, Result};
+use crate::paths::Paths;
+use crate::registry::Registry;
+use std::io::{self, BufRead, Write};
+
+use super::shared;
+
+/// Interactive prompts, abstracted so the menu is testable without a terminal.
+///
+/// Local to this command, and small on purpose: it mirrors [`super::super::setup`]'s
+/// `Prompter` rather than sharing it, so this front-end owns its own prompt
+/// styling without touching the setup wizard.
+///
+/// The empty line is load-bearing. Every prompt returns its `default` on both
+/// an empty line and EOF, and the menu chooses defaults that always terminate:
+/// `q` at the top level (so Enter and Ctrl-D both quit), and an empty string in
+/// the sub-flows (so Enter and Ctrl-D back out). That is what keeps the loop
+/// from spinning forever when stdin is exhausted.
+trait Prompter {
+    /// Ask a yes/no question. Empty line or EOF yields `default_yes`.
+    fn confirm(&mut self, message: &str, default_yes: bool) -> Result<bool>;
+
+    /// Print `message`, read one trimmed line. Empty line or EOF yields `default`.
+    fn input(&mut self, message: &str, default: &str) -> Result<String>;
+}
+
+/// The real prompter: reads from stdin.
+struct StdinPrompter;
+
+impl Prompter for StdinPrompter {
+    fn confirm(&mut self, message: &str, default_yes: bool) -> Result<bool> {
+        let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
+        print!("{message} {suffix} ");
+        flush()?;
+        let line = read_line()?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            Ok(default_yes)
+        } else {
+            Ok(trimmed.eq_ignore_ascii_case("y") || trimmed.eq_ignore_ascii_case("yes"))
+        }
+    }
+
+    fn input(&mut self, message: &str, default: &str) -> Result<String> {
+        print!("{message} ");
+        flush()?;
+        let line = read_line()?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            Ok(default.to_string())
+        } else {
+            Ok(trimmed.to_string())
+        }
+    }
+}
+
+fn flush() -> Result<()> {
+    io::stdout().flush().map_err(|e| Error::Io {
+        context: "flushing stdout".into(),
+        source: e,
+    })
+}
+
+fn read_line() -> Result<String> {
+    let mut input = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut input)
+        .map_err(|e| Error::Io {
+            context: "reading input".into(),
+            source: e,
+        })?;
+    Ok(input)
+}
+
+/// Run `akm skills shared`.
+///
+/// On an interactive terminal (and not `--plain`) this drives the menu;
+/// otherwise it prints the list and returns, so a pipe or an agent never hangs.
+pub fn run(paths: &Paths, plain: bool) -> Result<()> {
+    let mut config = Config::load(paths)?;
+
+    if !super::list::should_use_tui(plain) {
+        print_list(&config);
+        return Ok(());
+    }
+
+    let mut prompter = StdinPrompter;
+    run_menu(&mut prompter, paths, &mut config)
+}
+
+/// Print the configured registries, or the empty-state hint.
+///
+/// Shared by the non-interactive list path and the menu's reprint between
+/// actions. Reads the in-memory `Config` the loop keeps mutating, never disk.
+fn print_list(config: &Config) {
+    if config.shared.is_empty() {
+        println!("No shared registries configured.");
+        println!("Add one here, or with 'akm config shared.<name> <url>'.");
+        return;
+    }
+
+    println!("Shared registries:");
+    let width = config.shared.keys().map(String::len).max().unwrap_or(0);
+    for (name, url) in &config.shared {
+        println!("  {name:<width$}  {url}");
+    }
+}
+
+/// The menu loop: reprint the list, offer add/remove/quit, act, repeat.
+fn run_menu(prompter: &mut impl Prompter, paths: &Paths, config: &mut Config) -> Result<()> {
+    loop {
+        println!();
+        print_list(config);
+        println!();
+
+        let prompt = if config.shared.is_empty() {
+            "[a]dd / [q]uit >"
+        } else {
+            "[a]dd / [r]emove / [q]uit >"
+        };
+        // `q` default: Enter and EOF both quit.
+        let choice = prompter.input(prompt, "q")?;
+
+        match choice.to_ascii_lowercase().as_str() {
+            "a" | "add" => add_flow(prompter, paths, config)?,
+            "r" | "remove" if !config.shared.is_empty() => remove_flow(prompter, paths, config)?,
+            "q" | "quit" => return Ok(()),
+            _ => {} // anything else: reprint and ask again
+        }
+    }
+}
+
+/// Add a registry: name (validated, unique), URL (opaque), optional reachability check.
+fn add_flow(prompter: &mut impl Prompter, paths: &Paths, config: &mut Config) -> Result<()> {
+    let name = loop {
+        // Empty (Enter or EOF) backs out; a bad or taken name re-asks.
+        let name = prompter.input("Name:", "")?;
+        if name.is_empty() {
+            return Ok(());
+        }
+        if !is_valid_shared_name(&name) {
+            println!("Name must be a single segment with no '.' — try again.");
+            continue;
+        }
+        if config.shared.contains_key(&name) {
+            println!("'{name}' is already configured — pick another name.");
+            continue;
+        }
+        break name;
+    };
+
+    // The URL is opaque: it is handed to `git clone` later, so anything git can
+    // clone works (HTTPS, SSH, a local path). No host-sniffing, no validation.
+    let url = prompter.input("URL:", "")?;
+    if url.is_empty() {
+        return Ok(());
+    }
+
+    config.shared.insert(name.clone(), url.clone());
+    config.save(paths)?;
+    println!("Added '{name}'.");
+
+    if prompter.confirm("Verify it's reachable now?", false)? {
+        let registry = Registry::named(name.as_str(), url.as_str(), paths.shared_dir(&name));
+        println!("  {name}: {}", shared::refresh(&registry));
+    }
+
+    Ok(())
+}
+
+/// Remove a registry chosen by number, and delete its cached checkout.
+fn remove_flow(prompter: &mut impl Prompter, paths: &Paths, config: &mut Config) -> Result<()> {
+    // BTreeMap keys are sorted, so the numbering is stable for the whole prompt.
+    let names: Vec<String> = config.shared.keys().cloned().collect();
+
+    println!("Remove which?");
+    for (i, name) in names.iter().enumerate() {
+        println!("  {}) {name}", i + 1);
+    }
+
+    let index = loop {
+        // Empty (Enter or EOF) backs out to the menu.
+        let line = prompter.input("Number:", "")?;
+        if line.is_empty() {
+            return Ok(());
+        }
+        match line.parse::<usize>() {
+            Ok(n) if (1..=names.len()).contains(&n) => break n - 1,
+            _ => println!("Enter a number between 1 and {}.", names.len()),
+        }
+    };
+
+    let name = &names[index];
+    config.shared.remove(name);
+    config.save(paths)?;
+    // Best-effort: the checkout is reconstructible, and it may never have been
+    // browsed, so an absent dir or a failed delete is a no-op.
+    std::fs::remove_dir_all(paths.shared_dir(name)).ok();
+    println!("Removed '{name}'.");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::path::Path;
+    use std::process::Command;
+
+    /// A prompter that replays canned answers, then falls back to the default —
+    /// which is how EOF (an exhausted queue) is modelled.
+    struct TestPrompter {
+        responses: VecDeque<String>,
+    }
+
+    impl TestPrompter {
+        fn new(responses: &[&str]) -> Self {
+            Self {
+                responses: responses.iter().map(|s| s.to_string()).collect(),
+            }
+        }
+    }
+
+    impl Prompter for TestPrompter {
+        fn confirm(&mut self, _message: &str, default_yes: bool) -> Result<bool> {
+            match self.responses.pop_front() {
+                Some(r) if r.is_empty() => Ok(default_yes),
+                Some(r) => Ok(r.eq_ignore_ascii_case("y") || r.eq_ignore_ascii_case("yes")),
+                None => Ok(default_yes),
+            }
+        }
+
+        fn input(&mut self, _message: &str, default: &str) -> Result<String> {
+            match self.responses.pop_front() {
+                Some(r) if r.is_empty() => Ok(default.to_string()),
+                Some(r) => Ok(r),
+                None => Ok(default.to_string()),
+            }
+        }
+    }
+
+    fn temp_paths() -> (Paths, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_roots(
+            &tmp.path().join("data"),
+            &tmp.path().join("config"),
+            &tmp.path().join("cache"),
+            &tmp.path().join("home"),
+        );
+        (paths, tmp)
+    }
+
+    fn git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    #[test]
+    fn add_writes_the_entry_and_persists_it() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        // name, url, verify? -> no
+        let mut p = TestPrompter::new(&["acme", "git@example.com:acme.git", "n"]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert_eq!(
+            config.shared.get("acme").map(String::as_str),
+            Some("git@example.com:acme.git")
+        );
+        // Written through to disk, not just held in memory.
+        let reloaded = Config::load(&paths).unwrap();
+        assert_eq!(
+            reloaded.shared.get("acme").map(String::as_str),
+            Some("git@example.com:acme.git")
+        );
+        // "n" means no clone was attempted.
+        assert!(!paths.shared_dir("acme").exists());
+    }
+
+    #[test]
+    fn add_rejects_a_taken_name_then_takes_the_next() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("acme".into(), "git@example.com:acme.git".into());
+        // "acme" collides -> re-ask -> "other"
+        let mut p = TestPrompter::new(&["acme", "other", "git@example.com:other.git", "n"]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(config.shared.contains_key("other"));
+        // The existing entry is untouched.
+        assert_eq!(
+            config.shared.get("acme").map(String::as_str),
+            Some("git@example.com:acme.git")
+        );
+    }
+
+    #[test]
+    fn add_reprompts_on_an_invalid_name() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        // "a.b" has a dot -> re-ask -> "ok"
+        let mut p = TestPrompter::new(&["a.b", "ok", "git@example.com:ok.git", "n"]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(config.shared.contains_key("ok"));
+        assert!(!config.shared.contains_key("a.b"));
+    }
+
+    #[test]
+    fn add_cancels_on_an_empty_name() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        // No responses: the name prompt sees EOF and backs out.
+        let mut p = TestPrompter::new(&[]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(config.shared.is_empty());
+    }
+
+    #[test]
+    fn verify_no_does_not_clone() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        let mut p = TestPrompter::new(&["acme", "git@example.com:acme.git", "n"]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(!paths.shared_dir("acme").exists());
+    }
+
+    #[test]
+    fn verify_yes_clones_the_new_registry() {
+        let (paths, tmp) = temp_paths();
+        // A local bare repo stands in for the remote — no network in the test.
+        let origin = tmp.path().join("origin.git");
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&origin, &["init", "--bare", "-q"]);
+
+        let mut config = Config::default();
+        let mut p = TestPrompter::new(&["acme", &origin.to_string_lossy(), "y"]);
+
+        add_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(config.shared.contains_key("acme"));
+        assert!(paths.shared_dir("acme").exists());
+    }
+
+    #[test]
+    fn remove_drops_the_chosen_entry_and_its_cache() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("acme".into(), "git@example.com:acme.git".into());
+        config
+            .shared
+            .insert("beta".into(), "git@example.com:beta.git".into());
+        // Pretend "acme" was browsed once, leaving a checkout behind.
+        std::fs::create_dir_all(paths.shared_dir("acme")).unwrap();
+
+        // Sorted order is [acme, beta]; "1" removes acme.
+        let mut p = TestPrompter::new(&["1"]);
+        remove_flow(&mut p, &paths, &mut config).unwrap();
+
+        assert!(!config.shared.contains_key("acme"));
+        assert!(config.shared.contains_key("beta"));
+        assert!(!paths.shared_dir("acme").exists());
+    }
+
+    #[test]
+    fn remove_reprompts_on_a_bad_number_then_backs_out() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("acme".into(), "git@example.com:acme.git".into());
+        // out-of-range, then non-numeric, then EOF backs out.
+        let mut p = TestPrompter::new(&["9", "nope"]);
+
+        remove_flow(&mut p, &paths, &mut config).unwrap();
+
+        // Nothing removed.
+        assert!(config.shared.contains_key("acme"));
+    }
+
+    #[test]
+    fn menu_quits_on_q() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("acme".into(), "git@example.com:acme.git".into());
+        let mut p = TestPrompter::new(&["q"]);
+
+        run_menu(&mut p, &paths, &mut config).unwrap();
+    }
+
+    #[test]
+    fn menu_quits_on_eof() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        // Empty queue -> the top-level prompt sees EOF -> quit.
+        let mut p = TestPrompter::new(&[]);
+
+        run_menu(&mut p, &paths, &mut config).unwrap();
+    }
+
+    #[test]
+    fn menu_adds_then_quits() {
+        let (paths, _tmp) = temp_paths();
+        let mut config = Config::default();
+        // top: add; name; url; verify no; top: quit
+        let mut p = TestPrompter::new(&["a", "acme", "git@example.com:acme.git", "n", "q"]);
+
+        run_menu(&mut p, &paths, &mut config).unwrap();
+
+        assert!(config.shared.contains_key("acme"));
+    }
+}

--- a/src/commands/skills/sync.rs
+++ b/src/commands/skills/sync.rs
@@ -24,6 +24,7 @@ use crate::paths::Paths;
 use crate::registry::{Registry, SyncOutcome};
 
 use super::migrate::{self, Rc3Wipe};
+use super::shared;
 
 /// Result of a sync operation, used for display.
 #[derive(Debug)]
@@ -40,6 +41,8 @@ pub struct SyncReport {
     pub tool_dir_count: usize,
     /// Per-spec divergence after the update.
     pub drift: DriftReport,
+    /// One entry per configured shared registry: name, outcome, skill count.
+    pub shared: Vec<(String, shared::RefreshOutcome, usize)>,
 }
 
 /// Outcome of a single registry update attempt.
@@ -67,7 +70,18 @@ pub enum RegistryOutcome {
 }
 
 /// Execute the full sync pipeline.
-pub fn execute(paths: &Paths, registry: &Registry, tool_dirs: &ToolDirs) -> Result<SyncReport> {
+///
+/// `shared` is the outcome of refreshing the configured shared registries. It
+/// is passed in rather than computed here because nothing downstream of the
+/// personal registry depends on it: shared registries are browsable troves,
+/// never mounted, so refreshing one can neither add a symlink nor change the
+/// index.
+pub fn execute(
+    paths: &Paths,
+    registry: &Registry,
+    tool_dirs: &ToolDirs,
+    shared: Vec<(String, shared::RefreshOutcome, usize)>,
+) -> Result<SyncReport> {
     let library_dir = registry.dir().to_path_buf();
 
     // The wipe is only safe while a registry is configured to clone back from.
@@ -87,6 +101,7 @@ pub fn execute(paths: &Paths, registry: &Registry, tool_dirs: &ToolDirs) -> Resu
             symlink_count: 0,
             tool_dir_count: tool_dirs.count(),
             drift: DriftReport::default(),
+            shared,
         });
     }
 
@@ -127,6 +142,7 @@ pub fn execute(paths: &Paths, registry: &Registry, tool_dirs: &ToolDirs) -> Resu
         symlink_count,
         tool_dir_count: tool_dirs.count(),
         drift: registry.drift()?,
+        shared,
     })
 }
 
@@ -219,7 +235,29 @@ pub fn print_report(report: &SyncReport, quiet: bool) {
         report.symlink_count, report.tool_dir_count
     );
 
+    print_shared(&report.shared);
     print_drift(&report.drift);
+}
+
+/// Report each shared registry's refresh.
+///
+/// Informational only — nothing here is mounted, so an unreachable registry is
+/// a warning about browsing, not about this session's skills.
+fn print_shared(shared: &[(String, shared::RefreshOutcome, usize)]) {
+    if shared.is_empty() {
+        return;
+    }
+
+    println!();
+    println!("Shared registries:");
+    for (name, outcome, count) in shared {
+        match outcome {
+            shared::RefreshOutcome::Failed { .. } => {
+                println!("  {name}: {outcome}, browsing the copy on disk")
+            }
+            _ => println!("  {name}: {outcome} ({count} skills)"),
+        }
+    }
 }
 
 /// Report what needs a decision, without asking for one.
@@ -264,7 +302,8 @@ pub fn run_cli(paths: &Paths, quiet: bool) -> Result<()> {
         paths.library_dir(),
     );
 
-    let report = execute(paths, &registry, &tool_dirs)?;
+    let shared = shared::refresh_all(paths, &config);
+    let report = execute(paths, &registry, &tool_dirs, shared)?;
     print_report(&report, quiet);
 
     Ok(())

--- a/src/commands/skills/sync.rs
+++ b/src/commands/skills/sync.rs
@@ -43,6 +43,8 @@ pub struct SyncReport {
     pub drift: DriftReport,
     /// One entry per configured shared registry: name, outcome, skill count.
     pub shared: Vec<(String, shared::RefreshOutcome, usize)>,
+    /// Names of cached checkouts swept because config no longer names them.
+    pub swept: Vec<String>,
 }
 
 /// Outcome of a single registry update attempt.
@@ -102,6 +104,7 @@ pub fn execute(
             tool_dir_count: tool_dirs.count(),
             drift: DriftReport::default(),
             shared,
+            swept: Vec::new(),
         });
     }
 
@@ -143,6 +146,7 @@ pub fn execute(
         tool_dir_count: tool_dirs.count(),
         drift: registry.drift()?,
         shared,
+        swept: Vec::new(),
     })
 }
 
@@ -235,7 +239,7 @@ pub fn print_report(report: &SyncReport, quiet: bool) {
         report.symlink_count, report.tool_dir_count
     );
 
-    print_shared(&report.shared);
+    print_shared(&report.shared, &report.swept);
     print_drift(&report.drift);
 }
 
@@ -243,8 +247,8 @@ pub fn print_report(report: &SyncReport, quiet: bool) {
 ///
 /// Informational only — nothing here is mounted, so an unreachable registry is
 /// a warning about browsing, not about this session's skills.
-fn print_shared(shared: &[(String, shared::RefreshOutcome, usize)]) {
-    if shared.is_empty() {
+fn print_shared(shared: &[(String, shared::RefreshOutcome, usize)], swept: &[String]) {
+    if shared.is_empty() && swept.is_empty() {
         return;
     }
 
@@ -257,6 +261,10 @@ fn print_shared(shared: &[(String, shared::RefreshOutcome, usize)]) {
             }
             _ => println!("  {name}: {outcome} ({count} skills)"),
         }
+    }
+    // A cache vanishing silently is a debugging trap, so name what was swept.
+    for name in swept {
+        println!("  {name}: removed (no longer configured)");
     }
 }
 
@@ -303,7 +311,11 @@ pub fn run_cli(paths: &Paths, quiet: bool) -> Result<()> {
     );
 
     let shared = shared::refresh_all(paths, &config);
-    let report = execute(paths, &registry, &tool_dirs, shared)?;
+    let mut report = execute(paths, &registry, &tool_dirs, shared)?;
+    // Reconcile the cache against config: drop checkouts of registries that were
+    // removed with `akm config shared.<name> ""`, which cannot touch the cache
+    // itself. Sync is the only place with both the config and the paths.
+    report.swept = shared::sweep_orphans(paths, &config);
     print_report(&report, quiet);
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -489,6 +489,17 @@ pub const ALL_CONFIG_KEYS: &str = "features, registry.url, shared.<name>, \
      skills.personal-registry, artifacts.remote, artifacts.dir, artifacts.auto-push, \
      update.url, update.check-interval, update.auto-check";
 
+/// Whether `name` is a usable shared-registry name.
+///
+/// The rule — non-empty and single-segment (no `.`) — is shared by the
+/// `shared.<name>` config-key parser and the `akm skills shared` menu, so it
+/// lives here as one predicate rather than being spelled out in both. A
+/// predicate, not a `Result`: the menu re-prompts on a bad name, while the
+/// parser turns `false` into a `ConfigValidation` error.
+pub(crate) fn is_valid_shared_name(name: &str) -> bool {
+    !name.is_empty() && !name.contains('.')
+}
+
 impl std::str::FromStr for ConfigKey {
     type Err = Error;
 
@@ -507,7 +518,7 @@ impl std::str::FromStr for ConfigKey {
             // `shared.<name>` is open-ended: the suffix is the remote's name.
             other if other.starts_with("shared.") => {
                 let name = other.trim_start_matches("shared.");
-                if name.is_empty() || name.contains('.') {
+                if !is_valid_shared_name(name) {
                     return Err(Error::ConfigValidation {
                         key: other.to_string(),
                         message: "Expected 'shared.<name>' with a single-segment name".into(),
@@ -683,6 +694,13 @@ mod tests {
     #[test]
     fn config_key_from_str_unknown() {
         assert!("nonexistent.key".parse::<ConfigKey>().is_err());
+    }
+
+    #[test]
+    fn is_valid_shared_name_accepts_single_segment_only() {
+        assert!(is_valid_shared_name("foo"));
+        assert!(!is_valid_shared_name(""));
+        assert!(!is_valid_shared_name("a.b"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@
 use crate::error::{Error, IoContext, Result};
 use crate::paths::Paths;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 /// Default GitHub Releases API URL for update checks.
@@ -67,6 +67,13 @@ pub struct Config {
     /// Personal registry configuration section.
     #[serde(default)]
     pub registry: RegistryConfig,
+
+    /// Shared registries to browse and import from, keyed by name.
+    ///
+    /// Read-only troves: nothing here is ever mounted into a tool directory.
+    /// See [`Config::shared_remote`].
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub shared: BTreeMap<String, String>,
 
     /// Skills configuration section.
     #[serde(default)]
@@ -186,6 +193,7 @@ impl Default for Config {
         Self {
             features: BTreeSet::new(),
             registry: RegistryConfig::default(),
+            shared: BTreeMap::new(),
             skills: SkillsConfig::default(),
             artifacts: ArtifactsConfig::default(),
             update: UpdateConfig::default(),
@@ -231,7 +239,16 @@ impl Config {
 
         // Step 2: Walk the table tree and warn about unknown keys
         if let Some(table) = raw.as_table() {
-            let known_top: &[&str] = &["features", "registry", "skills", "artifacts", "update"];
+            // `shared` holds user-chosen remote names, so its keys are never
+            // checked against a known list.
+            let known_top: &[&str] = &[
+                "features",
+                "registry",
+                "shared",
+                "skills",
+                "artifacts",
+                "update",
+            ];
             let known_registry: &[&str] = &["url"];
             // `community_registry` is obsolete but still tolerated silently so
             // configs written before it was dropped do not warn on every run.
@@ -323,6 +340,15 @@ impl Config {
                             ),
                         }
                     }
+                    if let Some(shared) = table.get("shared") {
+                        match shared.clone().try_into::<BTreeMap<String, String>>() {
+                            Ok(s) => config.shared = s,
+                            Err(e) => eprintln!(
+                                "Warning: invalid [shared] config in {}, ignoring it: {e}",
+                                config_file.display()
+                            ),
+                        }
+                    }
                     if let Some(skills) = table.get("skills") {
                         match skills.clone().try_into::<SkillsConfig>() {
                             Ok(s) => config.skills = s,
@@ -404,15 +430,44 @@ impl Config {
             .or(self.skills.personal_registry.as_deref())
             .filter(|url| !url.is_empty())
     }
+
+    /// Resolve a shared remote name to its git URL.
+    ///
+    /// The error carries the configured names, because a typo'd remote is the
+    /// most likely reason to land here.
+    pub fn shared_remote(&self, name: &str) -> Result<&str> {
+        self.shared
+            .get(name)
+            .map(String::as_str)
+            .filter(|url| !url.is_empty())
+            .ok_or_else(|| Error::UnknownSharedRemote {
+                name: name.to_string(),
+                available: self.shared_names(),
+            })
+    }
+
+    /// Configured shared remote names, comma-separated. Empty when there are none.
+    pub fn shared_names(&self) -> String {
+        self.shared
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 /// Addressable config keys for the `akm config <key> [value]` command.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Not `Copy`: [`ConfigKey::Shared`] carries the remote's name, which is
+/// user-chosen rather than one of a fixed set.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigKey {
     /// `features` — comma-separated enabled features
     Features,
     /// `registry.url` — personal registry git URL
     RegistryUrl,
+    /// `shared.<name>` — git URL of a shared registry to import from
+    Shared(String),
     /// `skills.personal-registry` → `skills.personal_registry` (pre-rc4 alias)
     SkillsPersonalRegistry,
     /// `artifacts.remote`
@@ -430,8 +485,8 @@ pub enum ConfigKey {
 }
 
 /// All valid config key names for help text.
-pub const ALL_CONFIG_KEYS: &str = "features, registry.url, skills.personal-registry, \
-     artifacts.remote, artifacts.dir, artifacts.auto-push, \
+pub const ALL_CONFIG_KEYS: &str = "features, registry.url, shared.<name>, \
+     skills.personal-registry, artifacts.remote, artifacts.dir, artifacts.auto-push, \
      update.url, update.check-interval, update.auto-check";
 
 impl std::str::FromStr for ConfigKey {
@@ -449,6 +504,17 @@ impl std::str::FromStr for ConfigKey {
             "update.url" => Ok(ConfigKey::UpdateUrl),
             "update.check-interval" => Ok(ConfigKey::UpdateCheckInterval),
             "update.auto-check" => Ok(ConfigKey::UpdateAutoCheck),
+            // `shared.<name>` is open-ended: the suffix is the remote's name.
+            other if other.starts_with("shared.") => {
+                let name = other.trim_start_matches("shared.");
+                if name.is_empty() || name.contains('.') {
+                    return Err(Error::ConfigValidation {
+                        key: other.to_string(),
+                        message: "Expected 'shared.<name>' with a single-segment name".into(),
+                    });
+                }
+                Ok(ConfigKey::Shared(name.to_string()))
+            }
             other => Err(Error::UnknownConfigKey {
                 key: other.to_string(),
                 available: ALL_CONFIG_KEYS.to_string(),
@@ -468,6 +534,7 @@ impl ConfigKey {
                 .collect::<Vec<_>>()
                 .join(","),
             ConfigKey::RegistryUrl => config.registry_url().unwrap_or_default().to_string(),
+            ConfigKey::Shared(name) => config.shared.get(name).cloned().unwrap_or_default(),
             ConfigKey::SkillsPersonalRegistry => {
                 config.skills.personal_registry.clone().unwrap_or_default()
             }
@@ -507,6 +574,15 @@ impl ConfigKey {
                 // The alias would otherwise shadow nothing but still confuse
                 // anyone reading the file.
                 config.skills.personal_registry = None;
+            }
+            // An empty value removes the remote — the only way to drop one
+            // without hand-editing config.toml.
+            ConfigKey::Shared(name) => {
+                if value.is_empty() {
+                    config.shared.remove(name);
+                } else {
+                    config.shared.insert(name.clone(), value.to_string());
+                }
             }
             ConfigKey::SkillsPersonalRegistry => {
                 config.skills.personal_registry = if value.is_empty() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -198,6 +198,10 @@ pub enum Error {
     )]
     NoPersonalRegistry,
 
+    /// A shared registry was named that is not configured.
+    #[error("No shared registry named '{name}'.{}", available_hint(.available))]
+    UnknownSharedRemote { name: String, available: String },
+
     /// No SKILL.md found in directory.
     #[error("No SKILL.md found in {path}\nThe directory must contain a SKILL.md file (with optional supporting files).")]
     NoSkillMd { path: PathBuf },
@@ -306,6 +310,16 @@ pub enum Error {
 
 /// Convenience alias used throughout the codebase.
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// Tail of [`Error::UnknownSharedRemote`]: list what *is* configured, or say
+/// that nothing is, so the message is actionable either way.
+fn available_hint(available: &str) -> String {
+    if available.is_empty() {
+        "\nAdd one with 'akm config shared.<name> <git-url>'.".to_string()
+    } else {
+        format!("\nConfigured: {available}")
+    }
+}
 
 /// Extension trait for adding context to `std::io::Error`.
 pub trait IoContext<T> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -162,6 +162,37 @@ impl Git {
         Ok(())
     }
 
+    /// Create and switch to a new branch, off `start` or off the current HEAD.
+    pub fn checkout_new_branch(repo_dir: &Path, branch: &str, start: Option<&str>) -> Result<()> {
+        let mut args = vec!["checkout", "--quiet", "-b", branch];
+        if let Some(start) = start {
+            args.push(start);
+        }
+        run_git_ok(&args, Some(repo_dir))?;
+        Ok(())
+    }
+
+    /// Push a branch to `origin`, returning git's stderr.
+    ///
+    /// The stderr is the point, not a diagnostic: on a first push of a new
+    /// branch the *remote* answers with the URL for opening a pull (or merge)
+    /// request. Handing that back verbatim is what keeps AKM from having to
+    /// know one forge's URL shape from another's.
+    pub fn push_branch(repo_dir: &Path, branch: &str) -> Result<String> {
+        let output = run_git(
+            &["push", "--set-upstream", "origin", branch],
+            Some(repo_dir),
+        )?;
+        if output.success {
+            Ok(output.stderr)
+        } else {
+            Err(Error::Git {
+                args: format!("push --set-upstream origin {branch}"),
+                stderr: output.stderr,
+            })
+        }
+    }
+
     /// Stage all changes.
     pub fn add_all(repo_dir: &Path) -> Result<()> {
         run_git_ok(&["add", "-A"], Some(repo_dir))?;

--- a/src/library/libgen.rs
+++ b/src/library/libgen.rs
@@ -114,7 +114,12 @@ pub fn generate(scan_dir: &Path, out_path: &Path) -> Result<LibgenResult> {
 /// A sidecar that exists but does not parse is reported and left untouched —
 /// falling back in memory keeps the rest of the library usable without
 /// overwriting whatever the user was in the middle of editing.
-fn resolve_meta(library_dir: &Path, id: &str, spec_type: SpecType, md_file: &Path) -> SpecMeta {
+pub(crate) fn resolve_meta(
+    library_dir: &Path,
+    id: &str,
+    spec_type: SpecType,
+    md_file: &Path,
+) -> SpecMeta {
     let sidecar = spec_type.sidecar_path(library_dir, id);
 
     if sidecar.is_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,16 @@ enum SkillsCommands {
         #[arg(long)]
         plain: bool,
     },
+    /// Manage shared registries interactively
+    ///
+    /// On a terminal this opens an add/remove menu. Piped, redirected, or with
+    /// --plain, it prints the configured registries and exits. Scriptable writes
+    /// stay on `akm config shared.<name> <url>`.
+    Shared {
+        /// List the registries and exit, without the menu
+        #[arg(long)]
+        plain: bool,
+    },
     /// Remove stale specs
     Clean {
         /// Clean project directories
@@ -459,6 +469,9 @@ fn main() -> ExitCode {
                 }
                 Some(SkillsCommands::Status { plain }) => {
                     commands::skills::status::run(&paths, &tool_dirs, plain)
+                }
+                Some(SkillsCommands::Shared { plain }) => {
+                    commands::skills::shared_menu::run(&paths, plain)
                 }
                 Some(SkillsCommands::Clean { project, dry_run }) => {
                     commands::skills::clean::run(&paths, &tool_dirs, project, dry_run)

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ enum Commands {
     /// Keys:
     ///   features                  Enabled features (comma-separated: skills,artifacts,instructions)
     ///   registry.url              Registry git URL (canonical)
+    ///   shared.<name>             Git URL of a shared registry to import from (empty value removes)
     ///   skills.personal-registry  Pre-rc4 alias for registry.url
     ///   artifacts.remote          Artifacts repo git URL
     ///   artifacts.dir             Artifacts directory (default: ~/.akm/artifacts)
@@ -166,8 +167,13 @@ enum SkillsCommands {
         #[arg(required = true, add = ArgValueCandidates::new(SpecIdCompleter))]
         ids: Vec<String>,
     },
-    /// Browse library
+    /// Browse the library, or a shared registry
+    ///
+    /// With no argument, lists your own library. With REMOTE, lists what that
+    /// shared registry offers and marks the skills you already have.
     List {
+        /// Shared registry to browse (see `akm config shared.<name>`)
+        remote: Option<String>,
         /// Filter by tag
         #[arg(long)]
         tag: Option<String>,
@@ -209,16 +215,46 @@ enum SkillsCommands {
         #[arg(long)]
         force: bool,
     },
-    /// Import a skill from a GitHub URL into cold storage
+    /// Import a skill from a GitHub URL or a shared registry
+    ///
+    /// SOURCE is either a GitHub URL or the name of a configured shared
+    /// registry. Give SKILL_ID to take one skill from a registry, or --all to
+    /// take every valid skill the source offers.
+    ///
+    /// Examples:
+    ///   akm skills import https://github.com/acme/kit/tree/main/skills/tdd
+    ///   akm skills import acme tdd
+    ///   akm skills import acme --all
+    #[command(verbatim_doc_comment)]
     Import {
-        /// GitHub URL to a directory containing SKILL.md
-        url: String,
+        /// GitHub URL, or the name of a configured shared registry
+        source: String,
+        /// Skill to take from a shared registry
+        skill_id: Option<String>,
+        /// Import every valid skill the source offers
+        #[arg(long, conflicts_with = "skill_id")]
+        all: bool,
         /// Overwrite without confirmation
         #[arg(long)]
         force: bool,
-        /// Override the skill ID (default: last path segment from URL)
-        #[arg(long)]
+        /// Store the skill under this ID instead
+        #[arg(long, conflicts_with = "all")]
         id: Option<String>,
+    },
+    /// Offer a spec to a shared registry as a pull request
+    ///
+    /// Pushes the spec to REMOTE on its own branch and relays the URL the
+    /// remote prints for opening a pull (or merge) request. Nothing is merged:
+    /// the registry's owners decide. Requires permission to push a branch.
+    Share {
+        /// Shared registry to contribute to
+        remote: String,
+        /// Spec ID to share
+        #[arg(add = ArgValueCandidates::new(SpecIdCompleter))]
+        id: String,
+        /// Show what would be pushed, without pushing
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Edit a spec's markdown in $EDITOR
     Edit {
@@ -400,13 +436,24 @@ fn main() -> ExitCode {
                 Some(SkillsCommands::Remove { ids }) => {
                     commands::skills::remove::run(&paths, &ids, &tool_dirs)
                 }
-                Some(SkillsCommands::List { tag, r#type, plain }) => commands::skills::list::run(
-                    &paths,
-                    tag.as_deref(),
-                    r#type.as_deref(),
+                Some(SkillsCommands::List {
+                    remote,
+                    tag,
+                    r#type,
                     plain,
-                    &tool_dirs,
-                ),
+                }) => match remote {
+                    Some(remote) => {
+                        let config = akm::config::Config::load(&paths).unwrap_or_default();
+                        commands::skills::list::run_shared(&paths, &config, &remote)
+                    }
+                    None => commands::skills::list::run(
+                        &paths,
+                        tag.as_deref(),
+                        r#type.as_deref(),
+                        plain,
+                        &tool_dirs,
+                    ),
+                },
                 Some(SkillsCommands::Search { query, plain }) => {
                     commands::skills::search::run(&paths, &query, plain, &tool_dirs)
                 }
@@ -420,16 +467,51 @@ fn main() -> ExitCode {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
                     commands::skills::promote::run(&paths, &config, &path, force, &tool_dirs)
                 }
-                Some(SkillsCommands::Import { url, force, id }) => {
+                Some(SkillsCommands::Import {
+                    source,
+                    skill_id,
+                    all,
+                    force,
+                    id,
+                }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
-                    commands::skills::import::run(
-                        &paths,
-                        &config,
-                        &url,
-                        force,
-                        id.as_deref(),
-                        &tool_dirs,
-                    )
+                    let from_registry = config.shared.contains_key(&source);
+                    match (skill_id, all) {
+                        (Some(skill_id), _) => commands::skills::import::run_remote(
+                            &paths,
+                            &config,
+                            &source,
+                            &skill_id,
+                            force,
+                            id.as_deref(),
+                            &tool_dirs,
+                        ),
+                        (None, true) if from_registry => commands::skills::import::run_all_remote(
+                            &paths, &config, &source, force, &tool_dirs,
+                        ),
+                        (None, true) => commands::skills::import::run_all_url(
+                            &paths, &config, &source, force, &tool_dirs,
+                        ),
+                        // A bare registry name is ambiguous on its own: it
+                        // names a source but not what to take from it.
+                        (None, false) if from_registry => Err(error::Error::ConfigValidation {
+                            key: "import".into(),
+                            message: format!(
+                                "'{source}' is a shared registry. Name a skill \
+                                 ('akm skills import {source} <id>'), take everything \
+                                 ('akm skills import {source} --all'), or see what it has \
+                                 ('akm skills list {source}')."
+                            ),
+                        }),
+                        (None, false) => commands::skills::import::run(
+                            &paths,
+                            &config,
+                            &source,
+                            force,
+                            id.as_deref(),
+                            &tool_dirs,
+                        ),
+                    }
                 }
                 Some(SkillsCommands::Edit { id, meta }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
@@ -449,6 +531,14 @@ fn main() -> ExitCode {
                         Some(id) => commands::skills::publish::run(&paths, &config, &id, dry_run),
                         None => commands::skills::publish::run_all(&paths, &config, dry_run),
                     }
+                }
+                Some(SkillsCommands::Share {
+                    remote,
+                    id,
+                    dry_run,
+                }) => {
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
+                    commands::skills::share::run(&paths, &config, &remote, &id, dry_run)
                 }
                 Some(SkillsCommands::Diff { id }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -165,6 +165,21 @@ impl Paths {
         self.cache_dir.join(session_id)
     }
 
+    /// `$XDG_CACHE_HOME/akm/shared/<name>/` — checkout of a shared registry.
+    ///
+    /// In the cache, not the data dir, because it is neither owned nor mounted:
+    /// nothing here is ever symlinked into a tool directory, and a shared
+    /// registry is only ever read from, so the whole tree is reconstructible
+    /// from its remote. Deleting it costs one clone.
+    pub fn shared_dir(&self, name: &str) -> PathBuf {
+        self.cache_dir.join("shared").join(name)
+    }
+
+    /// Root of every shared registry checkout: `$XDG_CACHE_HOME/akm/shared/`.
+    pub fn shared_root(&self) -> PathBuf {
+        self.cache_dir.join("shared")
+    }
+
     // --- AKM home (non-XDG, user-visible) ---
 
     /// `$HOME/.akm` — artifacts root, global instructions

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -48,19 +48,34 @@ pub enum PublishOutcome {
     NothingToDo,
 }
 
-/// A git-backed personal registry, checked out at `dir`.
+/// A git-backed registry, checked out at `dir`.
 pub struct Registry {
+    name: String,
     url: String,
     dir: PathBuf,
 }
 
 impl Registry {
-    /// Construct a registry handle. Does not touch the filesystem.
+    /// Construct a handle to the personal registry. Does not touch the filesystem.
     pub fn new(url: impl Into<String>, dir: impl Into<PathBuf>) -> Self {
+        Self::named("personal", url, dir)
+    }
+
+    /// Construct a handle to a named registry.
+    ///
+    /// The name only ever reaches the user through [`Error::RegistrySync`], so
+    /// a failure says which registry failed once more than one is in play.
+    pub fn named(name: impl Into<String>, url: impl Into<String>, dir: impl Into<PathBuf>) -> Self {
         Self {
+            name: name.into(),
             url: url.into(),
             dir: dir.into(),
         }
+    }
+
+    /// The registry's name, as used in error messages and reports.
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// The configured remote URL (empty when unconfigured).
@@ -86,7 +101,7 @@ impl Registry {
     /// Clone the registry into the library directory.
     pub fn clone_fresh(&self) -> Result<()> {
         Git::clone(&self.url, &self.dir).map_err(|e| Error::RegistrySync {
-            name: "personal".into(),
+            name: self.name.clone(),
             message: format!("Clone failed: {e}"),
         })
     }
@@ -101,7 +116,7 @@ impl Registry {
     /// so one unresolved skill can never freeze the other forty-nine.
     pub fn update(&self) -> Result<SyncOutcome> {
         Git::fetch(&self.dir).map_err(|e| Error::RegistrySync {
-            name: "personal".into(),
+            name: self.name.clone(),
             message: format!("Fetch failed: {e}"),
         })?;
 
@@ -156,7 +171,7 @@ impl Registry {
     /// merely unpublished, and the push that follows is rejected.
     pub fn refresh(&self) -> Result<()> {
         Git::fetch(&self.dir).map_err(|e| Error::RegistrySync {
-            name: "personal".into(),
+            name: self.name.clone(),
             message: format!("Fetch failed: {e}"),
         })
     }
@@ -294,10 +309,49 @@ impl Registry {
             .collect())
     }
 
+    /// Switch to the branch a contribution will be pushed on.
+    ///
+    /// Starts from the remote's copy of that branch when it already has one, so
+    /// re-sharing a spec fast-forwards an open pull request instead of being
+    /// rejected as a non-fast-forward.
+    pub fn checkout_contribution_branch(&self, branch: &str) -> Result<()> {
+        let remote_branch = format!("origin/{branch}");
+        let start = Git::rev_parse(&self.dir, &remote_branch)
+            .ok()
+            .map(|_| remote_branch);
+        Git::checkout_new_branch(&self.dir, branch, start.as_deref())
+    }
+
+    /// Commit `pathspecs` on the current branch and push it to `origin`.
+    ///
+    /// Returns git's stderr, which carries the forge's own "open a pull
+    /// request" URL — see [`Git::push_branch`].
+    pub fn push_contribution(
+        &self,
+        branch: &str,
+        pathspecs: &[String],
+        message: &str,
+    ) -> Result<Option<String>> {
+        let refs: Vec<&str> = pathspecs.iter().map(String::as_str).collect();
+
+        Git::add_path(&self.dir, &refs)?;
+        if Git::is_staging_clean(&self.dir)? {
+            return Ok(None);
+        }
+
+        Git::commit(&self.dir, message)?;
+        Git::push_branch(&self.dir, branch)
+            .map(Some)
+            .map_err(|e| Error::RegistrySync {
+                name: self.name.clone(),
+                message: format!("Push failed: {e}"),
+            })
+    }
+
     /// Push, reporting a failure as a registry-sync error.
     fn push(&self) -> Result<()> {
         Git::push(&self.dir).map_err(|e| Error::RegistrySync {
-            name: "personal".into(),
+            name: self.name.clone(),
             message: format!("Push failed: {e}"),
         })
     }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -111,3 +111,56 @@ auto_push = true
     let normalized = stdout.replace(&config_dir.display().to_string(), "<CONFIG_DIR>");
     insta::assert_snapshot!(normalized);
 }
+
+/// Shared registries are addressed by a name the user chooses, so the key is
+/// open-ended where every other config key is one of a fixed set.
+#[test]
+fn shared_registries_round_trip_and_can_be_removed() {
+    let tmp = TempDir::new().unwrap();
+    let env_args = [
+        ("XDG_CONFIG_HOME", tmp.path().join("config")),
+        ("XDG_DATA_HOME", tmp.path().join("data")),
+        ("XDG_CACHE_HOME", tmp.path().join("cache")),
+        ("HOME", tmp.path().to_path_buf()),
+    ];
+    let run = |args: &[&str]| {
+        let mut cmd = akm_cmd();
+        cmd.args(args);
+        for (k, v) in &env_args {
+            cmd.env(k, v);
+        }
+        cmd.output().unwrap()
+    };
+
+    run(&["config", "shared.acme", "git@github.com:acme/skills.git"]);
+    let out = run(&["config", "shared.acme"]);
+    assert!(String::from_utf8_lossy(&out.stdout).contains("git@github.com:acme/skills.git"));
+
+    // Two registries coexist, and both show up in the full listing.
+    run(&["config", "shared.oss", "https://github.com/oss/skills.git"]);
+    let out = run(&["config"]);
+    let listing = String::from_utf8_lossy(&out.stdout);
+    assert!(listing.contains("shared.acme"));
+    assert!(listing.contains("shared.oss"));
+
+    // An empty value removes one, which is the only way to drop a registry
+    // without hand-editing config.toml.
+    run(&["config", "shared.acme", ""]);
+    let out = run(&["config"]);
+    let listing = String::from_utf8_lossy(&out.stdout);
+    assert!(!listing.contains("shared.acme"));
+    assert!(listing.contains("shared.oss"));
+}
+
+#[test]
+fn a_shared_key_without_a_name_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    akm_cmd()
+        .args(["config", "shared.", "url"])
+        .env("XDG_CONFIG_HOME", tmp.path().join("config"))
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .env("XDG_CACHE_HOME", tmp.path().join("cache"))
+        .env("HOME", tmp.path())
+        .assert()
+        .failure();
+}

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -38,6 +38,21 @@ fn test_skills_help_output_snapshot() {
     );
 }
 
+/// `shared` has a TTY-vs-pipe split and a `--plain` escape hatch, so its help —
+/// and the fact that it takes no verb subcommands — is pinned.
+#[test]
+fn test_shared_help_output_snapshot() {
+    let output = cargo_bin_cmd!("akm")
+        .args(["skills", "shared", "--help"])
+        .output()
+        .unwrap();
+
+    insta::assert_snapshot!(
+        "shared_help_output",
+        String::from_utf8_lossy(&output.stdout).to_string()
+    );
+}
+
 /// Rename and delete are destructive/structural, so their contract — argument
 /// order and `delete`'s `--force` — is pinned.
 #[test]

--- a/tests/skills_core_publish_test.rs
+++ b/tests/skills_core_publish_test.rs
@@ -112,7 +112,13 @@ impl Env {
             self.config.registry_url().unwrap(),
             self.paths.library_dir(),
         );
-        sync::execute(&self.paths, &registry, &ToolDirs::builtin(&self.home)).unwrap();
+        sync::execute(
+            &self.paths,
+            &registry,
+            &ToolDirs::builtin(&self.home),
+            Vec::new(),
+        )
+        .unwrap();
         identify(&self.paths.library_dir());
     }
 

--- a/tests/skills_drift_commands_test.rs
+++ b/tests/skills_drift_commands_test.rs
@@ -103,7 +103,7 @@ impl Env {
             self.config.registry_url().unwrap(),
             self.paths.library_dir(),
         );
-        sync::execute(&self.paths, &registry, &self.tool_dirs()).unwrap();
+        sync::execute(&self.paths, &registry, &self.tool_dirs(), Vec::new()).unwrap();
         let library_dir = self.paths.library_dir();
         git(&library_dir, &["config", "user.email", "test@example.com"]);
         git(&library_dir, &["config", "user.name", "Test"]);

--- a/tests/skills_publish_test.rs
+++ b/tests/skills_publish_test.rs
@@ -132,7 +132,13 @@ impl Env {
             self.config.registry_url().unwrap(),
             self.paths.library_dir(),
         );
-        sync::execute(&self.paths, &registry, &ToolDirs::builtin(&self.home)).unwrap();
+        sync::execute(
+            &self.paths,
+            &registry,
+            &ToolDirs::builtin(&self.home),
+            Vec::new(),
+        )
+        .unwrap();
         identify(&self.paths.library_dir());
     }
 

--- a/tests/skills_shared_test.rs
+++ b/tests/skills_shared_test.rs
@@ -12,6 +12,7 @@ use akm::library::libgen;
 use akm::library::tool_dirs::ToolDirs;
 use akm::library::Library;
 use akm::paths::Paths;
+use assert_cmd::cargo::cargo_bin_cmd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
@@ -475,4 +476,49 @@ fn a_registry_that_was_never_cloned_is_an_error() {
 
     let err = list::run_shared(&env.paths, &env.config, "acme").unwrap_err();
     assert!(format!("{err}").contains("acme"));
+}
+
+/// Run `akm skills shared` against an isolated home. Captured stdout is not a
+/// terminal, so this exercises the non-interactive read path an agent or a pipe
+/// hits: it prints and exits, never waiting for a menu answer.
+fn run_shared_cli(tmp: &TempDir, config_toml: Option<&str>) -> std::process::Output {
+    let config_dir = tmp.path().join("config");
+    if let Some(toml) = config_toml {
+        std::fs::create_dir_all(config_dir.join("akm")).unwrap();
+        std::fs::write(config_dir.join("akm/config.toml"), toml).unwrap();
+    }
+    cargo_bin_cmd!("akm")
+        .args(["skills", "shared"])
+        .env("XDG_CONFIG_HOME", &config_dir)
+        .env("XDG_DATA_HOME", tmp.path().join("data"))
+        .env("XDG_CACHE_HOME", tmp.path().join("cache"))
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn piped_shared_prints_the_list_and_exits() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_shared_cli(
+        &tmp,
+        Some("[shared]\nacme = \"git@github.com:acme/skills.git\"\n"),
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Shared registries:"));
+    assert!(stdout.contains("acme"));
+    assert!(stdout.contains("git@github.com:acme/skills.git"));
+}
+
+#[test]
+fn piped_shared_with_no_registries_prints_the_hint() {
+    let tmp = TempDir::new().unwrap();
+    let output = run_shared_cli(&tmp, None);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("No shared registries configured."));
+    assert!(stdout.contains("akm config shared.<name> <url>"));
 }

--- a/tests/skills_shared_test.rs
+++ b/tests/skills_shared_test.rs
@@ -1,0 +1,478 @@
+//! End-to-end shared registries: browse, import, contribute back.
+//!
+//! A shared registry is somebody else's repository, so these tests stand one up
+//! as a real git remote and drive the whole loop against it. What they are
+//! really pinning down is the boundary: importing copies files into the
+//! personal library and nothing else, and sharing pushes a branch and nothing
+//! else.
+
+use akm::commands::skills::{import, list, share, shared};
+use akm::config::Config;
+use akm::library::libgen;
+use akm::library::tool_dirs::ToolDirs;
+use akm::library::Library;
+use akm::paths::Paths;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn skill_md(id: &str, body: &str) -> String {
+    format!("---\nname: {id}\ndescription: desc for {id}\n---\n{body}\n")
+}
+
+/// Give the test process a git identity.
+///
+/// `share` commits inside a clone it creates and destroys itself, so unlike
+/// every other checkout in these tests there is nothing for `git config` to be
+/// run against. Without this the suite would quietly lean on the developer's
+/// global git config and fail on a machine that has none — CI, for one.
+fn identify_process() {
+    for (key, value) in [
+        ("GIT_AUTHOR_NAME", "Test"),
+        ("GIT_AUTHOR_EMAIL", "test@example.com"),
+        ("GIT_COMMITTER_NAME", "Test"),
+        ("GIT_COMMITTER_EMAIL", "test@example.com"),
+    ] {
+        std::env::set_var(key, value);
+    }
+}
+
+struct Env {
+    _tmp: TempDir,
+    /// Bare repository standing in for the shared registry's remote.
+    origin: PathBuf,
+    /// A checkout of it, standing in for whoever maintains that registry.
+    upstream: PathBuf,
+    paths: Paths,
+    config: Config,
+    home: PathBuf,
+}
+
+impl Env {
+    /// A shared registry holding two usable skills and two that are not.
+    fn new() -> Self {
+        identify_process();
+        let tmp = TempDir::new().unwrap();
+        let origin = tmp.path().join("origin.git");
+        git(tmp.path(), &["init", "--bare", "-b", "main", "origin.git"]);
+
+        let upstream = tmp.path().join("upstream");
+        git(
+            tmp.path(),
+            &["clone", "--quiet", &origin.to_string_lossy(), "upstream"],
+        );
+        git(&upstream, &["config", "user.email", "test@example.com"]);
+        git(&upstream, &["config", "user.name", "Test"]);
+
+        for id in ["house-style", "tdd"] {
+            write(
+                &upstream.join(format!("skills/{id}/SKILL.md")),
+                &skill_md(id, "v1"),
+            );
+        }
+        // The registry's owner considers this one core. That is a statement
+        // about their machines, not about ours.
+        write(
+            &upstream.join("skills/house-style/akm.json"),
+            r#"{"name":"house-style","description":"the house style","tags":["style"],"core":true,"triggers":{}}"#,
+        );
+        // Neither of these is importable.
+        write(&upstream.join("skills/notes/README.md"), "just notes\n");
+        write(
+            &upstream.join("skills/half-written/SKILL.md"),
+            "---\nname: half-written\n---\nno description\n",
+        );
+
+        git(&upstream, &["add", "-A"]);
+        git(&upstream, &["commit", "-m", "initial"]);
+        git(&upstream, &["push", "--quiet", "-u", "origin", "main"]);
+
+        let home = tmp.path().join("home");
+        let paths = Paths::from_roots(
+            &tmp.path().join("data"),
+            &tmp.path().join("config"),
+            &tmp.path().join("cache"),
+            &home,
+        );
+
+        let mut config = Config::default();
+        config
+            .shared
+            .insert("acme".to_string(), origin.to_string_lossy().to_string());
+
+        Self {
+            _tmp: tmp,
+            origin,
+            upstream,
+            paths,
+            config,
+            home,
+        }
+    }
+
+    fn tool_dirs(&self) -> ToolDirs {
+        ToolDirs::builtin(&self.home)
+    }
+
+    fn import(&self, id: &str) {
+        import::run_remote(
+            &self.paths,
+            &self.config,
+            "acme",
+            id,
+            false,
+            None,
+            &self.tool_dirs(),
+        )
+        .unwrap();
+    }
+
+    fn import_all(&self) {
+        import::run_all_remote(&self.paths, &self.config, "acme", false, &self.tool_dirs())
+            .unwrap();
+    }
+
+    fn library(&self) -> Library {
+        Library::load_from(&self.paths.library_json()).unwrap()
+    }
+
+    fn skill(&self, id: &str) -> PathBuf {
+        self.paths.library_dir().join("skills").join(id)
+    }
+
+    /// Put a skill of our own in the personal library, ready to share.
+    fn author(&self, id: &str, body: &str) {
+        write(&self.skill(id).join("SKILL.md"), &skill_md(id, body));
+        libgen::generate(&self.paths.library_dir(), &self.paths.library_json()).unwrap();
+    }
+
+    /// Publish a change to the shared registry, as its maintainer would.
+    fn upstream_commit(&self, rel: &str, content: &str) {
+        write(&self.upstream.join(rel), content);
+        git(&self.upstream, &["add", "-A"]);
+        git(&self.upstream, &["commit", "-m", &format!("update {rel}")]);
+        git(&self.upstream, &["push", "--quiet"]);
+    }
+}
+
+#[test]
+fn browsing_clones_the_registry_and_reads_what_it_offers() {
+    let env = Env::new();
+
+    list::run_shared(&env.paths, &env.config, "acme").unwrap();
+
+    let registry = shared::open(&env.paths, &env.config, "acme").unwrap();
+    assert_eq!(registry.dir(), env.paths.shared_dir("acme"));
+    assert!(registry.is_cloned());
+
+    let catalogue = shared::catalogue(registry.dir()).unwrap();
+    let ids: Vec<&str> = catalogue.skills.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(ids, vec!["house-style", "tdd"]);
+
+    // Unusable directories are reported rather than silently dropped.
+    let skipped: Vec<&str> = catalogue.skipped.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(skipped, vec!["half-written", "notes"]);
+}
+
+/// The registry lives in the cache and is never mounted: no symlink, and
+/// nothing outside the personal library points into it.
+#[test]
+fn a_shared_registry_is_never_mounted() {
+    let env = Env::new();
+
+    list::run_shared(&env.paths, &env.config, "acme").unwrap();
+
+    assert!(env
+        .paths
+        .shared_dir("acme")
+        .starts_with(env.paths.cache_dir()));
+    assert!(!env.home.join(".claude/skills/house-style").exists());
+    assert!(!env.paths.library_json().exists());
+}
+
+#[test]
+fn importing_copies_the_skill_into_the_personal_library() {
+    let env = Env::new();
+
+    env.import("tdd");
+
+    assert!(env.skill("tdd").join("SKILL.md").is_file());
+    let library = env.library();
+    let spec = library.get("tdd").expect("tdd is in the library");
+    assert_eq!(spec.description, "desc for tdd");
+    assert!(spec.source.as_deref().unwrap().contains("acme"));
+}
+
+/// `core: true` in a shared registry is its owner's statement about their own
+/// machines. Importing must not turn it into a global mount here.
+#[test]
+fn core_is_not_inherited_from_a_shared_registry() {
+    let env = Env::new();
+
+    env.import("house-style");
+
+    let library = env.library();
+    assert!(!library.get("house-style").unwrap().core);
+    assert!(!env.home.join(".claude/skills/house-style").exists());
+}
+
+#[test]
+fn import_all_takes_every_valid_skill_and_leaves_the_rest() {
+    let env = Env::new();
+
+    env.import_all();
+
+    let library = env.library();
+    assert!(library.contains("tdd"));
+    assert!(library.contains("house-style"));
+    assert!(!library.contains("notes"));
+    assert!(!library.contains("half-written"));
+}
+
+/// Re-running an import must be a no-op while nothing has moved, or `--all`
+/// would ask about every skill in the registry every time.
+///
+/// Once the registry *has* moved, the update is a clash like any other: AKM
+/// does not record which version was taken, so it cannot tell an untouched
+/// import from a local rewrite. Without a terminal to ask, that means `--force`
+/// — with one, the prompt offers mine/theirs/both.
+#[test]
+fn re_importing_is_idempotent_until_the_registry_moves() {
+    let env = Env::new();
+    env.import_all();
+
+    env.import_all();
+    assert_eq!(env.library().len(), 2);
+
+    env.upstream_commit("skills/tdd/SKILL.md", &skill_md("tdd", "v2 from upstream"));
+
+    let err = import::run_remote(
+        &env.paths,
+        &env.config,
+        "acme",
+        "tdd",
+        false,
+        None,
+        &env.tool_dirs(),
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("--force"));
+
+    import::run_remote(
+        &env.paths,
+        &env.config,
+        "acme",
+        "tdd",
+        true,
+        None,
+        &env.tool_dirs(),
+    )
+    .unwrap();
+    assert!(std::fs::read_to_string(env.skill("tdd").join("SKILL.md"))
+        .unwrap()
+        .contains("v2 from upstream"));
+}
+
+/// Without a terminal there is nobody to ask, so a clash leaves the local copy
+/// alone. A batch says so and carries on; a single import fails outright, which
+/// is what it has always done.
+#[test]
+fn a_clash_keeps_the_local_copy_when_nobody_can_be_asked() {
+    let env = Env::new();
+    env.author("tdd", "MY OWN VERSION");
+
+    env.import_all();
+
+    assert!(std::fs::read_to_string(env.skill("tdd").join("SKILL.md"))
+        .unwrap()
+        .contains("MY OWN VERSION"));
+    // The skill that did not clash still came through.
+    assert!(env.skill("house-style").join("SKILL.md").is_file());
+
+    let err = import::run_remote(
+        &env.paths,
+        &env.config,
+        "acme",
+        "tdd",
+        false,
+        None,
+        &env.tool_dirs(),
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("already exists"));
+}
+
+#[test]
+fn force_takes_the_registrys_version() {
+    let env = Env::new();
+    env.author("tdd", "MY OWN VERSION");
+
+    import::run_remote(
+        &env.paths,
+        &env.config,
+        "acme",
+        "tdd",
+        true,
+        None,
+        &env.tool_dirs(),
+    )
+    .unwrap();
+
+    assert!(std::fs::read_to_string(env.skill("tdd").join("SKILL.md"))
+        .unwrap()
+        .contains("v1"));
+}
+
+/// `--id` is how you keep both without being asked: the incoming copy lands
+/// under a name of your choosing.
+#[test]
+fn an_import_can_be_stored_under_another_id() {
+    let env = Env::new();
+    env.author("tdd", "MY OWN VERSION");
+
+    import::run_remote(
+        &env.paths,
+        &env.config,
+        "acme",
+        "tdd",
+        false,
+        Some("acme-tdd"),
+        &env.tool_dirs(),
+    )
+    .unwrap();
+
+    let library = env.library();
+    assert!(library.contains("tdd"));
+    assert!(library.contains("acme-tdd"));
+    assert!(std::fs::read_to_string(env.skill("tdd").join("SKILL.md"))
+        .unwrap()
+        .contains("MY OWN VERSION"));
+}
+
+#[test]
+fn sharing_pushes_a_branch_and_leaves_the_default_branch_alone() {
+    let env = Env::new();
+    env.author("my-skill", "something worth sharing");
+
+    share::run(&env.paths, &env.config, "acme", "my-skill", false).unwrap();
+
+    // The contribution is on its own branch...
+    let on_branch = git(
+        &env.origin,
+        &["show", "akm/my-skill:skills/my-skill/SKILL.md"],
+    );
+    assert!(on_branch.contains("something worth sharing"));
+
+    // ...and main is untouched, because merging is the registry owner's call.
+    let main_files = git(&env.origin, &["ls-tree", "-r", "--name-only", "main"]);
+    assert!(!main_files.contains("my-skill"));
+}
+
+/// Re-sharing has to fast-forward the branch an open pull request is built on,
+/// not be rejected for having diverged from it.
+#[test]
+fn sharing_again_updates_the_existing_branch() {
+    let env = Env::new();
+    env.author("my-skill", "first draft");
+    share::run(&env.paths, &env.config, "acme", "my-skill", false).unwrap();
+
+    env.author("my-skill", "second draft");
+    share::run(&env.paths, &env.config, "acme", "my-skill", false).unwrap();
+
+    let on_branch = git(
+        &env.origin,
+        &["show", "akm/my-skill:skills/my-skill/SKILL.md"],
+    );
+    assert!(on_branch.contains("second draft"));
+    assert_eq!(
+        git(&env.origin, &["rev-list", "--count", "main..akm/my-skill"]),
+        "2"
+    );
+}
+
+#[test]
+fn sharing_an_unchanged_spec_pushes_nothing() {
+    let env = Env::new();
+    env.author("my-skill", "one and only draft");
+    share::run(&env.paths, &env.config, "acme", "my-skill", false).unwrap();
+
+    let before = git(&env.origin, &["rev-parse", "akm/my-skill"]);
+    share::run(&env.paths, &env.config, "acme", "my-skill", false).unwrap();
+    let after = git(&env.origin, &["rev-parse", "akm/my-skill"]);
+
+    assert_eq!(before, after);
+}
+
+#[test]
+fn an_unconfigured_registry_names_the_ones_that_are() {
+    let env = Env::new();
+
+    let err = list::run_shared(&env.paths, &env.config, "typo").unwrap_err();
+    let message = format!("{err}");
+    assert!(message.contains("typo"));
+    assert!(message.contains("acme"));
+}
+
+/// An unreachable registry must not cost you the copy you already have.
+#[test]
+fn browsing_falls_back_to_the_copy_on_disk_when_the_remote_is_gone() {
+    let env = Env::new();
+    list::run_shared(&env.paths, &env.config, "acme").unwrap();
+
+    std::fs::remove_dir_all(&env.origin).unwrap();
+
+    list::run_shared(&env.paths, &env.config, "acme").unwrap();
+    let catalogue = shared::catalogue(&env.paths.shared_dir("acme")).unwrap();
+    assert_eq!(catalogue.skills.len(), 2);
+}
+
+/// A failure is printed inside a one-line entry in `akm skills sync`'s report,
+/// but git answers a failed fetch with a paragraph.
+#[test]
+fn an_unreachable_registry_reports_on_one_line() {
+    let env = Env::new();
+    let registry = shared::open(&env.paths, &env.config, "acme").unwrap();
+    shared::refresh(&registry);
+
+    std::fs::remove_dir_all(&env.origin).unwrap();
+
+    let outcome = shared::refresh(&registry);
+    let rendered = format!("{outcome}");
+    assert_eq!(rendered.lines().count(), 1, "rendered as: {rendered}");
+    assert!(rendered.starts_with("unreachable ("));
+    // The entry it lands in already begins with the registry's name.
+    assert!(!rendered.contains("Failed to sync registry"));
+}
+
+/// The first clone is the one case where an unreachable registry is fatal:
+/// there is nothing on disk to fall back to.
+#[test]
+fn a_registry_that_was_never_cloned_is_an_error() {
+    let env = Env::new();
+    std::fs::remove_dir_all(&env.origin).unwrap();
+
+    let err = list::run_shared(&env.paths, &env.config, "acme").unwrap_err();
+    assert!(format!("{err}").contains("acme"));
+}

--- a/tests/skills_sync_test.rs
+++ b/tests/skills_sync_test.rs
@@ -91,6 +91,7 @@ impl Env {
             &self.paths,
             &self.registry(),
             &ToolDirs::builtin(&self.home),
+            Vec::new(),
         )
         .unwrap()
     }
@@ -408,7 +409,13 @@ fn sync_without_a_registry_uses_what_is_on_disk() {
     );
 
     let registry = Registry::new("", env.paths.library_dir());
-    let report = sync::execute(&env.paths, &registry, &ToolDirs::builtin(&env.home)).unwrap();
+    let report = sync::execute(
+        &env.paths,
+        &registry,
+        &ToolDirs::builtin(&env.home),
+        Vec::new(),
+    )
+    .unwrap();
 
     assert!(matches!(report.registry, RegistryOutcome::Skipped));
     assert_eq!(report.spec_count, Some(1));
@@ -489,7 +496,13 @@ fn an_rc3_layout_is_kept_when_no_registry_is_configured() {
     env.make_rc3_layout();
 
     let registry = Registry::new("", env.paths.library_dir());
-    let report = sync::execute(&env.paths, &registry, &ToolDirs::builtin(&env.home)).unwrap();
+    let report = sync::execute(
+        &env.paths,
+        &registry,
+        &ToolDirs::builtin(&env.home),
+        Vec::new(),
+    )
+    .unwrap();
 
     assert!(report.migration.is_empty());
     assert!(env.paths.data_dir().join("skills/stale/SKILL.md").is_file());

--- a/tests/snapshots/help_test__import_help_output.snap
+++ b/tests/snapshots/help_test__import_help_output.snap
@@ -2,15 +2,38 @@
 source: tests/help_test.rs
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
-Import a skill from a GitHub URL into cold storage
+Import a skill from a GitHub URL or a shared registry
 
-Usage: akm skills import [OPTIONS] <URL>
+SOURCE is either a GitHub URL or the name of a configured shared
+registry. Give SKILL_ID to take one skill from a registry, or --all to
+take every valid skill the source offers.
+
+Examples:
+  akm skills import https://github.com/acme/kit/tree/main/skills/tdd
+  akm skills import acme tdd
+  akm skills import acme --all
+
+Usage: akm skills import [OPTIONS] <SOURCE> [SKILL_ID]
 
 Arguments:
-  <URL>  GitHub URL to a directory containing SKILL.md
+  <SOURCE>
+          GitHub URL, or the name of a configured shared registry
+
+  [SKILL_ID]
+          Skill to take from a shared registry
 
 Options:
-      --force    Overwrite without confirmation
-      --id <ID>  Override the skill ID (default: last path segment from URL)
-  -h, --help     Print help
-  -V, --version  Print version
+      --all
+          Import every valid skill the source offers
+
+      --force
+          Overwrite without confirmation
+
+      --id <ID>
+          Store the skill under this ID instead
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/snapshots/help_test__shared_help_output.snap
+++ b/tests/snapshots/help_test__shared_help_output.snap
@@ -1,0 +1,19 @@
+---
+source: tests/help_test.rs
+expression: "String::from_utf8_lossy(&output.stdout).to_string()"
+---
+Manage shared registries interactively
+
+On a terminal this opens an add/remove menu. Piped, redirected, or with --plain, it prints the configured registries and exits. Scriptable writes stay on `akm config shared.<name> <url>`.
+
+Usage: akm skills shared [OPTIONS]
+
+Options:
+      --plain
+          List the registries and exit, without the menu
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -10,12 +10,13 @@ Commands:
   sync     Pull remote → cold library → rebuild symlinks
   add      Add spec(s) to project manifest
   remove   Remove spec(s) from project manifest
-  list     Browse library
+  list     Browse the library, or a shared registry
   search   Search library by keyword
   status   Full status overview
   clean    Remove stale specs
   promote  Import local skill into cold storage
-  import   Import a skill from a GitHub URL into cold storage
+  import   Import a skill from a GitHub URL or a shared registry
+  share    Offer a spec to a shared registry as a pull request
   edit     Edit a spec's markdown in $EDITOR
   rename   Rename a spec's id (its slug / directory name)
   delete   Delete a spec from the library (and the personal registry)

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -13,6 +13,7 @@ Commands:
   list     Browse the library, or a shared registry
   search   Search library by keyword
   status   Full status overview
+  shared   Manage shared registries interactively
   clean    Remove stale specs
   promote  Import local skill into cold storage
   import   Import a skill from a GitHub URL or a shared registry


### PR DESCRIPTION
Closes #35.

## The model

Shared registries are a **trove you pluck from**, not a second mounted library.
You browse one, import what you want, and the copy becomes an ordinary personal
skill from that moment on.

That reframing — which came out of grilling the design rather than the issue
text — is what makes this small. Both footguns in #35 stop existing:

- **flat-namespace collisions**: nothing shared is mounted, so there is no
  precedence rule to invent in the one namespace whose names are also the
  strings a model matches on;
- **per-registry drift/publish**: the personal registry stays the only writable
  one, so drift, publish, revert and core stay singular.

Untouched as a result: `Spec`, `library.json`, `symlinks`, `session_setup`,
`drift`, `core`, `manifest`, `Paths::library_dir()`.

## Surface

```bash
akm config shared.acme git@github.com:acme/skills.git   # add (existing command)
akm config shared.acme ""                               # remove

akm skills list acme          # what it offers, marking what you already have
akm skills import acme tdd    # take one
akm skills import acme --all  # take everything usable
akm skills import <url> --all # same, for a GitHub URL

akm skills share acme my-skill  # offer one of yours back
```

`publish` and `share` are deliberately different verbs: `publish` writes to
*your* registry on your own authority, `share` offers a copy to someone else's
and waits for their review.

## Decisions worth flagging

**Contributing is git-only.** `share` pushes a branch and relays git's stderr
verbatim — the *remote* prints the "create a pull request / merge request" URL
on a first push, so GitLab, Gitea and Bitbucket work without AKM knowing one
forge's URL shape from another, and no token is involved. Re-sharing branches
from the remote's copy of `akm/<id>`, so an open PR fast-forwards instead of
being rejected. It needs permission to push a branch, not to write to `main`.

**`acme-tdd`, not `acme:tdd`.** The "keep both" id is the mounted directory
name and the model's trigger string. Plugin skills *display* as
`superpowers:brainstorming`, but on disk they are plain directory names inside
a plugin-scoped path — there is no `:` in any directory under `~/.claude`. AKM
mounts into a flat `~/.claude/skills/<id>` with no scope to synthesise from, so
`:` would have to be a real directory name: invalid in Claude Code's `name`
frontmatter and reserved on NTFS/exFAT. Provenance goes in the sidecar's
existing `source` field instead.

**`core: true` is never inherited.** That flag means "core on my machines",
which is its owner's call about their machines. Imports land unmounted.

**Clones live in the cache**, not the data dir: reconstructible from the
remote, owned by nobody here, and `akm uninstall` already wipes it.

## Verification

- 27 test suites green, including a new `tests/skills_shared_test.rs` (16 tests)
  driving the whole loop against a real git remote: browse, import, `--all`,
  clash handling, share, re-share, unreachable-remote fallback.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Two help snapshots updated (intentional CLI contract change).
- Manually exercised end to end against a scratch registry, which caught two
  things the tests missed: git's multi-line stderr leaking into sync's one-line
  report (fixed, with a regression test), and the suite silently depending on
  the developer's global git identity — it now supplies its own and passes with
  `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`, i.e. in CI.

## Known gaps, deliberately left

- **No update tracking.** AKM does not record which version of a skill was
  imported, so it cannot tell an untouched import from a local rewrite. Taking
  an upstream update is a re-import, which is a normal clash: the prompt offers
  mine/theirs/both, and non-interactively it needs `--force`. A "3 imported
  skills have moved upstream" line on sync is the natural follow-up.
- **No fuse/rename/pick** for two same-named skills after the fact — follow-up
  issue, as agreed.
- **`share` needs a git identity.** It commits inside a clone it creates and
  destroys, so only global/system git config applies and there is no checkout
  to configure. A user without one gets git's own canonical "Please tell me who
  you are" message, after the clone. Not pre-flighted: git already explains it.
- No `search <remote>`, no TUI for `list <remote>`, no forge-API PR creation.

Plan: `~/.akm/artifacts/akm-rs/plans/2026-08-04-shared-registries.md`

---

## Update — interactive `akm skills shared` + sync sweep

On top of the above, in this branch:

- **`akm skills shared`** — the human front-end for `[shared]`. On a terminal it
  loops a small add/remove menu; piped, redirected, or with `--plain` it prints
  the configured registries and exits (the agent/pipe read path — it never
  hangs). Writes still go through `config.save`, and the scriptable
  `akm config shared.<name>` path is untouched: one writer of truth, the new
  command is purely a front-end plus a read path.
- **Sync sweep** — `akm skills sync` now deletes cached checkouts of registries
  config no longer names, giving the scriptable removal path
  (`akm config shared.<name> ""`) the same cache cleanup the interactive remove
  does. Reported in the sync output, not silent.
- The `shared.<name>` name-format rule is extracted to `is_valid_shared_name`,
  shared by the config-key parser and the menu instead of being duplicated.

Verification for the addition: `skills_shared_test.rs` is now 18 tests (2 new CLI
integration tests — piped → plain list, empty → hint); new `shared_menu` unit
tests (add / collision / invalid-name / remove / verify-y+n / quit / EOF-as-quit)
and `sweep_orphans` unit tests (incl. missing-root); new `shared_help_output`
snapshot and an updated `skills_help_output`. Full `cargo test`,
`cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` green.

Plan: `~/.akm/artifacts/akm-rs/plans/2026-08-13-shared-menu-command.md`