### PR TITLE
feat(skills): rename + delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,31 @@ akm-rs is a CLI tool for AKM (Agent Kit Manager). It manages a shared library of
 skills, agents and instructions and wires them into coding harnesses per project
 and per session.
 
+## Philosophy
+
+AKM is meant to feel like Obsidian. It is a tool you use on **one machine** — a
+local library of skills, agents and instructions that you edit and wire into
+your harnesses. If you want the same library on another machine you **opt in to
+sync**, and from then on it just stays in step. Sync has its own rules (see the
+README's "Keeping in step with the registry" and `docs/`), but the user should
+**never have to think about them**, and must **never** be told to go run git by
+hand. "Resolve it in the library repository" is a bug, not an answer.
+
+Git is an implementation detail. Today AKM leans on git directly — the library
+*is* the registry's working tree — because that buys drift, history and
+ours-wins reconciliation without a database, and keeps the binary dependency-free.
+That is a deliberate trade to avoid over-engineering, not a constraint: git must
+stay **below the surface**. Any place a git concept (rebase, conflict, detached
+HEAD, "non-fast-forward") reaches the user is a place to fix — by having AKM do
+the reconciliation on their behalf in terms of *specs*, not commits.
+
+When git starts doing too much — anything stateful git is a poor fit for, e.g.
+tracking skill activations, monitoring sessions, or recording user actions over
+time — reach for a local store (a SQLite DB under the XDG data dir is the
+intended tool) rather than contorting git. The bar for adding that machinery: it
+either removes a git-detour the user would otherwise hit, or it backs a stateful
+feature git genuinely cannot. Not before.
+
 ## Tech stack
 
 Rust (MSRV 1.88).

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ another project's manifest keeps its old (or now-deleted) id there until that
 project is updated. In the `list` TUI, `R` renames the selected spec and `D`
 deletes it; the publish offer appears after you quit the TUI.
 
+Publishing a rename or delete lands on top of the registry the same way an
+edit does: if the remote moved on since your last sync, AKM fast-forwards onto
+it first and then commits your change, so the push is never rejected. If another
+machine changed the very same spec, your rename/delete wins (its old id is gone
+and the new one holds your version) — no git conflict, and you are never dropped
+into the library to sort out history by hand.
+
 #### Keeping in step with the registry
 
 Your library is the registry's git working tree, so AKM answers "who is newer"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ akm skills remove vitest         # remove from project manifest
 akm skills status                # full status dashboard (TUI)
 akm skills edit my-skill         # edit SKILL.md in $EDITOR
 akm skills edit my-skill --meta  # edit the skill's akm.json sidecar
+akm skills rename old new         # rename a spec's id (its slug / directory name)
+akm skills delete my-skill       # delete a spec from the library (and the registry)
 akm skills diff my-skill         # what changed here, and what changed on the registry
 akm skills revert my-skill       # discard local changes (--remote: take the registry's copy)
 akm skills core                  # show core flags (--adopt / --publish to reconcile)
@@ -127,6 +129,16 @@ akm skills publish my-skill      # publish one spec to personal registry
 akm skills publish               # publish everything pending, in one commit
 akm skills clean --dry-run       # preview stale spec removal
 ```
+
+`remove` and `delete` are different verbs: `remove` only unwires a spec from the
+current project's manifest, while `delete` takes it out of the library
+entirely — files, index, core symlinks — and offers to push the removal to the
+personal registry. `rename` likewise moves the spec's files and fixes up the
+current project's manifest and this machine's core override. Both `rename` and
+`delete` can only reach the *current* repository's manifest; a spec referenced by
+another project's manifest keeps its old (or now-deleted) id there until that
+project is updated. In the `list` TUI, `R` renames the selected spec and `D`
+deletes it; the publish offer appears after you quit the TUI.
 
 #### Keeping in step with the registry
 

--- a/src/commands/skills/delete.rs
+++ b/src/commands/skills/delete.rs
@@ -1,0 +1,148 @@
+//! `akm skills delete` — remove a spec from the library (and the registry).
+//!
+//! This is the destructive counterpart to `remove`, which only unwires a spec
+//! from a project manifest. Delete takes the spec's files off disk, rebuilds
+//! the derived index and core symlinks without it, drops its machine-local core
+//! override and its entry in the current project's manifest.
+//!
+//! Because it is irreversible it confirms first: `[y/N]` on a terminal, or an
+//! explicit `--force` when there is no TTY to ask on. When a personal registry
+//! is configured it then offers to publish the removal, so the spec is gone
+//! from the remote too — subject to the caveat that manifests in *other*
+//! repositories still reference the deleted id and cannot be reached from here.
+
+use crate::config::Config;
+use crate::error::{Error, IoContext, Result};
+use crate::library::libgen;
+use crate::library::local::LocalOverrides;
+use crate::library::manifest::Manifest;
+use crate::library::spec::SpecType;
+use crate::library::symlinks;
+use crate::library::tool_dirs::ToolDirs;
+use crate::library::Library;
+use crate::paths::Paths;
+use std::env;
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+/// Run the `akm skills delete` command.
+pub fn run(
+    paths: &Paths,
+    config: &Config,
+    id: &str,
+    force: bool,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    // Resolve first, so a typo gets "no such spec" rather than a prompt.
+    let library = Library::load_checked(paths)?;
+    let spec = library
+        .get(id)
+        .ok_or_else(|| Error::SpecNotFound { id: id.to_string() })?;
+    let spec_type = spec.spec_type;
+    let pathspecs = spec.pathspecs();
+
+    if !force && !confirm(id, spec_type)? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    apply(paths, id, tool_dirs)?;
+
+    // Drop it from the current project's manifest too. Manifests in other
+    // repositories reference the deleted id and cannot be reached from here.
+    remove_from_current_manifest(id, spec_type, tool_dirs)?;
+
+    println!("Deleted {spec_type} '{id}' from the library");
+
+    let message = format!("chore: remove {spec_type} '{id}'");
+    super::publish::offer_pathspecs(paths, config, &pathspecs, &message);
+
+    Ok(())
+}
+
+/// Perform the library-level delete: remove files, rebuild the index without
+/// the spec, drop its local override and rebuild core symlinks.
+///
+/// Reused by the TUI. Does not touch project manifests, session symlinks, or
+/// the remote.
+pub fn apply(paths: &Paths, id: &str, tool_dirs: &ToolDirs) -> Result<()> {
+    let library_dir = paths.library_dir();
+    let library = Library::load_checked(paths)?;
+    let spec = library
+        .get(id)
+        .ok_or_else(|| Error::SpecNotFound { id: id.to_string() })?;
+    let spec_type = spec.spec_type;
+
+    remove_files(&library_dir, spec_type, id)?;
+
+    libgen::generate(&library_dir, &paths.library_json())?;
+    let mut library = Library::load_from(&paths.library_json())?;
+    let mut overrides = LocalOverrides::load_from(&paths.local_json())?;
+    overrides.clear_core(id);
+    overrides.apply(&mut library);
+    overrides.save_to(&paths.local_json())?;
+    library.save_to(&paths.library_json())?;
+
+    symlinks::rebuild_core(&library.core_specs(), &library_dir, tool_dirs.dirs())?;
+
+    Ok(())
+}
+
+/// Delete a spec's files from disk.
+fn remove_files(library_dir: &Path, spec_type: SpecType, id: &str) -> Result<()> {
+    match spec_type {
+        SpecType::Skill => {
+            let dir = library_dir.join("skills").join(id);
+            std::fs::remove_dir_all(&dir).io_context(format!("Removing {}", dir.display()))?;
+        }
+        SpecType::Agent => {
+            let agents = library_dir.join("agents");
+            let md = agents.join(format!("{id}.md"));
+            std::fs::remove_file(&md).io_context(format!("Removing {}", md.display()))?;
+
+            let sidecar = agents.join(format!("{id}.akm.json"));
+            if sidecar.is_file() {
+                std::fs::remove_file(&sidecar)
+                    .io_context(format!("Removing {}", sidecar.display()))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drop the deleted id from the current project's manifest, if present.
+fn remove_from_current_manifest(id: &str, spec_type: SpecType, tool_dirs: &ToolDirs) -> Result<()> {
+    let Ok(project_root) = crate::git::Git::toplevel(None) else {
+        return Ok(());
+    };
+    if !Manifest::path(&project_root).exists() {
+        return Ok(());
+    }
+
+    let mut manifest = Manifest::load(&project_root)?;
+    if manifest.remove(id, Some(spec_type)) {
+        manifest.save()?;
+
+        if let Some(staging) = env::var("AKM_SESSION").ok().map(PathBuf::from) {
+            if staging.is_dir() {
+                let _ = symlinks::remove_session(id, &staging, &tool_dirs.staging_names());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Ask before deleting. Non-interactive callers must pass `--force`.
+fn confirm(id: &str, spec_type: SpecType) -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        return Err(Error::ConfirmationRequired {
+            action: format!("delete {spec_type} '{id}' from the library"),
+        });
+    }
+
+    print!("Delete {spec_type} '{id}' from the library? [y/N]: ");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    Ok(input.trim().eq_ignore_ascii_case("y"))
+}

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -5,6 +5,7 @@
 pub mod add;
 pub mod clean;
 pub mod core;
+pub mod delete;
 pub mod diff;
 pub mod edit;
 pub mod import;

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -14,6 +14,7 @@ pub mod migrate;
 pub mod promote;
 pub mod publish;
 pub mod remove;
+pub mod rename;
 pub mod revert;
 pub mod search;
 pub mod session_setup;

--- a/src/commands/skills/publish.rs
+++ b/src/commands/skills/publish.rs
@@ -227,11 +227,13 @@ pub(crate) fn offer_pathspecs(paths: &Paths, config: &Config, pathspecs: &[Strin
 
 /// Refresh, then commit and push an explicit pathspec set.
 ///
-/// Unlike the single-spec path there is no ours-wins rebase: a remote that has
-/// diverged on these paths will reject the push, which is surfaced as-is.
+/// Fast-forwards onto the remote before committing (see
+/// [`Registry::publish_worktree`]), so a remote that moved on — even on the same
+/// paths — is landed on top of rather than rejected, and the user is never left
+/// with a diverged local commit to resolve in git by hand.
 fn publish_pathspecs(registry: &Registry, pathspecs: &[String], message: &str) -> Result<()> {
     registry.refresh()?;
-    match registry.publish(pathspecs, message)? {
+    match registry.publish_worktree(pathspecs, message)? {
         PublishOutcome::NothingToDo => println!("No changes to publish."),
         PublishOutcome::Published => println!("Pushed to {}", registry.url()),
     }

--- a/src/commands/skills/publish.rs
+++ b/src/commands/skills/publish.rs
@@ -191,6 +191,53 @@ fn show_dry_run(registry: &Registry, spec: &Spec, state: DriftState) -> Result<(
     Ok(())
 }
 
+/// Offer to publish an explicit set of paths to the personal registry.
+///
+/// Used by rename and delete, whose change spans paths that do not map to a
+/// single live spec id (a rename touches both the old and new paths; a delete
+/// removes a spec entirely). Silently does nothing unless stdin is a TTY and a
+/// personal registry is cloned. A failed publish is a warning, never a hard
+/// error: the local library change has already landed.
+pub(crate) fn offer_pathspecs(paths: &Paths, config: &Config, pathspecs: &[String], message: &str) {
+    if !io::stdin().is_terminal() {
+        return;
+    }
+    let Some(url) = config.registry_url() else {
+        return;
+    };
+    let registry = Registry::new(url, paths.library_dir());
+    if !registry.is_cloned() {
+        return;
+    }
+
+    println!();
+    print!("Publish to personal registry? [y/N]: ");
+    io::stdout().flush().ok();
+    let mut input = String::new();
+    io::stdin().lock().read_line(&mut input).ok();
+    if !input.trim().eq_ignore_ascii_case("y") {
+        return;
+    }
+
+    if let Err(e) = publish_pathspecs(&registry, pathspecs, message) {
+        eprintln!("Warning: publish failed: {e}");
+        eprintln!("Retry with: akm skills publish");
+    }
+}
+
+/// Refresh, then commit and push an explicit pathspec set.
+///
+/// Unlike the single-spec path there is no ours-wins rebase: a remote that has
+/// diverged on these paths will reject the push, which is surfaced as-is.
+fn publish_pathspecs(registry: &Registry, pathspecs: &[String], message: &str) -> Result<()> {
+    registry.refresh()?;
+    match registry.publish(pathspecs, message)? {
+        PublishOutcome::NothingToDo => println!("No changes to publish."),
+        PublishOutcome::Published => println!("Pushed to {}", registry.url()),
+    }
+    Ok(())
+}
+
 /// Offer to publish `id` to the personal registry, after a promote or import.
 ///
 /// Silently does nothing unless stdin is a TTY and a personal registry is

--- a/src/commands/skills/rename.rs
+++ b/src/commands/skills/rename.rs
@@ -1,0 +1,204 @@
+//! `akm skills rename` — change a spec's id (its slug / directory name).
+//!
+//! The id is what a human types to invoke a skill as `/<slug>`, so renaming it
+//! is a filesystem move, not a metadata edit: `skills/<old>` becomes
+//! `skills/<new>` (or the agent's `<old>.md` + `<old>.akm.json` pair is moved).
+//! The derived index and core symlinks are rebuilt from the new layout, and the
+//! machine-local core override is carried across so the rename does not quietly
+//! reset it.
+//!
+//! Like `edit`, this offers to publish when a personal registry is configured —
+//! the push carries both the deletion of the old paths and the addition of the
+//! new ones, so the remote is renamed too.
+
+use crate::config::Config;
+use crate::error::{Error, IoContext, Result};
+use crate::library::libgen;
+use crate::library::local::LocalOverrides;
+use crate::library::manifest::Manifest;
+use crate::library::spec::SpecType;
+use crate::library::symlinks;
+use crate::library::tool_dirs::ToolDirs;
+use crate::library::Library;
+use crate::paths::Paths;
+use std::env;
+use std::path::PathBuf;
+
+/// Run the `akm skills rename` command.
+pub fn run(
+    paths: &Paths,
+    config: &Config,
+    old: &str,
+    new: &str,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let spec_type = apply(paths, old, new, tool_dirs)?;
+
+    // Fix the current project's manifest too. Manifests in other repositories
+    // reference the old id and cannot be reached from here.
+    update_current_manifest(old, new, spec_type, tool_dirs)?;
+
+    println!("Renamed {spec_type} '{old}' -> '{new}'");
+
+    let mut pathspecs = spec_type.pathspecs(old);
+    pathspecs.extend(spec_type.pathspecs(new));
+    let message = format!("refactor: rename {spec_type} '{old}' -> '{new}'");
+    super::publish::offer_pathspecs(paths, config, &pathspecs, &message);
+
+    Ok(())
+}
+
+/// Perform the library-level rename: validate, move files, rebuild the index,
+/// carry the local override across and rebuild core symlinks.
+///
+/// Reused by the TUI. Does not touch project manifests, session symlinks, or
+/// the remote. Returns the renamed spec's type.
+pub fn apply(paths: &Paths, old: &str, new: &str, tool_dirs: &ToolDirs) -> Result<SpecType> {
+    let library_dir = paths.library_dir();
+    let library = Library::load_checked(paths)?;
+
+    let spec = library.get(old).ok_or_else(|| Error::SpecNotFound {
+        id: old.to_string(),
+    })?;
+    let spec_type = spec.spec_type;
+
+    validate_id(new)?;
+    if library.contains(new) {
+        return Err(Error::SpecAlreadyExists {
+            id: new.to_string(),
+        });
+    }
+
+    move_files(&library_dir, spec_type, old, new)?;
+
+    // Rebuild the derived index from the new on-disk layout, then fold in this
+    // machine's core deviations — moving the renamed spec's entry first so the
+    // preference survives the id change.
+    libgen::generate(&library_dir, &paths.library_json())?;
+    let mut library = Library::load_from(&paths.library_json())?;
+    let mut overrides = LocalOverrides::load_from(&paths.local_json())?;
+    overrides.rename(old, new);
+    overrides.apply(&mut library);
+    overrides.save_to(&paths.local_json())?;
+    library.save_to(&paths.library_json())?;
+
+    symlinks::rebuild_core(&library.core_specs(), &library_dir, tool_dirs.dirs())?;
+
+    Ok(spec_type)
+}
+
+/// Move a spec's files from `old` to `new` on disk.
+fn move_files(
+    library_dir: &std::path::Path,
+    spec_type: SpecType,
+    old: &str,
+    new: &str,
+) -> Result<()> {
+    match spec_type {
+        SpecType::Skill => {
+            let from = library_dir.join("skills").join(old);
+            let to = library_dir.join("skills").join(new);
+            std::fs::rename(&from, &to).io_context(format!(
+                "Renaming {} to {}",
+                from.display(),
+                to.display()
+            ))?;
+        }
+        SpecType::Agent => {
+            let agents = library_dir.join("agents");
+            let from_md = agents.join(format!("{old}.md"));
+            let to_md = agents.join(format!("{new}.md"));
+            std::fs::rename(&from_md, &to_md).io_context(format!(
+                "Renaming {} to {}",
+                from_md.display(),
+                to_md.display()
+            ))?;
+
+            // The sidecar is optional — only present once someone curated metadata.
+            let from_side = agents.join(format!("{old}.akm.json"));
+            if from_side.is_file() {
+                let to_side = agents.join(format!("{new}.akm.json"));
+                std::fs::rename(&from_side, &to_side).io_context(format!(
+                    "Renaming {} to {}",
+                    from_side.display(),
+                    to_side.display()
+                ))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Rewrite the current project's manifest entry, if it references `old`.
+fn update_current_manifest(
+    old: &str,
+    new: &str,
+    spec_type: SpecType,
+    tool_dirs: &ToolDirs,
+) -> Result<()> {
+    let Ok(project_root) = crate::git::Git::toplevel(None) else {
+        return Ok(());
+    };
+    if !Manifest::path(&project_root).exists() {
+        return Ok(());
+    }
+
+    let mut manifest = Manifest::load(&project_root)?;
+    if manifest.remove(old, Some(spec_type)) {
+        manifest.add(new, spec_type);
+        manifest.save()?;
+
+        // Drop the stale session symlink; the new one is created next session.
+        if let Some(staging) = env::var("AKM_SESSION").ok().map(PathBuf::from) {
+            if staging.is_dir() {
+                let _ = symlinks::remove_session(old, &staging, &tool_dirs.staging_names());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reject ids that are not usable slugs / directory names.
+fn validate_id(id: &str) -> Result<()> {
+    let reason = if id.is_empty() {
+        Some("must not be empty")
+    } else if id == "." || id == ".." {
+        Some("must not be '.' or '..'")
+    } else if id.contains('/') || id.contains('\\') {
+        Some("must not contain path separators")
+    } else if id.chars().any(char::is_whitespace) {
+        Some("must not contain whitespace")
+    } else {
+        None
+    };
+
+    match reason {
+        Some(reason) => Err(Error::InvalidSpecId {
+            id: id.to_string(),
+            reason: reason.to_string(),
+        }),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_id_rejects_bad_slugs() {
+        assert!(validate_id("").is_err());
+        assert!(validate_id(".").is_err());
+        assert!(validate_id("..").is_err());
+        assert!(validate_id("a/b").is_err());
+        assert!(validate_id("a\\b").is_err());
+        assert!(validate_id("a b").is_err());
+    }
+
+    #[test]
+    fn validate_id_accepts_ordinary_slugs() {
+        assert!(validate_id("git-commit").is_ok());
+        assert!(validate_id("tdd_workflow").is_ok());
+        assert!(validate_id("code-review-agent").is_ok());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,10 @@ pub enum Error {
     #[error("Invalid spec type: '{value}' (expected 'skill' or 'agent')")]
     InvalidSpecType { value: String },
 
+    /// Proposed spec id is not a usable slug.
+    #[error("Invalid spec id '{id}': {reason}")]
+    InvalidSpecId { id: String, reason: String },
+
     /// Frontmatter missing required field.
     #[error("Missing required frontmatter field '{field}' in {path}\nAdd '{field}: ...' to the YAML frontmatter.")]
     FrontmatterMissing { field: String, path: PathBuf },

--- a/src/library/local.rs
+++ b/src/library/local.rs
@@ -86,6 +86,17 @@ impl LocalOverrides {
         self.core.remove(id);
     }
 
+    /// Move any deviation from `old` to `new`, following a spec rename.
+    ///
+    /// Without this the entry for `old` would be dropped by [`Self::apply`] as
+    /// a stale id, silently resetting the renamed spec to its published core
+    /// default on this machine.
+    pub fn rename(&mut self, old: &str, new: &str) {
+        if let Some(value) = self.core.remove(old) {
+            self.core.insert(new.to_string(), value);
+        }
+    }
+
     /// Number of specs deviating from their published default.
     pub fn deviation_count(&self) -> usize {
         self.core.len()

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,14 @@ enum SkillsCommands {
         #[arg(long)]
         meta: bool,
     },
+    /// Rename a spec's id (its slug / directory name)
+    Rename {
+        /// Current spec ID
+        #[arg(add = ArgValueCandidates::new(SpecIdCompleter))]
+        old: String,
+        /// New spec ID
+        new: String,
+    },
     /// Publish spec to personal registry
     Publish {
         /// Spec ID to publish. Omit to publish everything pending.
@@ -417,6 +425,10 @@ fn main() -> ExitCode {
                 Some(SkillsCommands::Edit { id, meta }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
                     commands::skills::edit::run(&paths, &config, &id, meta, &tool_dirs)
+                }
+                Some(SkillsCommands::Rename { old, new }) => {
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
+                    commands::skills::rename::run(&paths, &config, &old, &new, &tool_dirs)
                 }
                 Some(SkillsCommands::Publish { id, dry_run }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,15 @@ enum SkillsCommands {
         /// New spec ID
         new: String,
     },
+    /// Delete a spec from the library (and the personal registry)
+    Delete {
+        /// Spec ID to delete
+        #[arg(add = ArgValueCandidates::new(SpecIdCompleter))]
+        id: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        force: bool,
+    },
     /// Publish spec to personal registry
     Publish {
         /// Spec ID to publish. Omit to publish everything pending.
@@ -429,6 +438,10 @@ fn main() -> ExitCode {
                 Some(SkillsCommands::Rename { old, new }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();
                     commands::skills::rename::run(&paths, &config, &old, &new, &tool_dirs)
+                }
+                Some(SkillsCommands::Delete { id, force }) => {
+                    let config = akm::config::Config::load(&paths).unwrap_or_default();
+                    commands::skills::delete::run(&paths, &config, &id, force, &tool_dirs)
                 }
                 Some(SkillsCommands::Publish { id, dry_run }) => {
                     let config = akm::config::Config::load(&paths).unwrap_or_default();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -191,6 +191,109 @@ impl Registry {
         Ok(PublishOutcome::Published)
     }
 
+    /// Publish uncommitted working-tree changes to `pathspecs`, keeping the
+    /// push a fast-forward.
+    ///
+    /// rename and delete leave their change in the working tree, uncommitted.
+    /// Committing straight onto a remote that has moved on since the last sync
+    /// would fork history: the push would be rejected and the user left with a
+    /// diverged local commit to untangle in git by hand — exactly the kind of
+    /// bare-git detour AKM exists to spare them. So the branch is fast-forwarded
+    /// onto the remote *first*, and only then does the change get committed on
+    /// top, where the push cannot be refused.
+    ///
+    /// When the update would overwrite our own change (both sides touched the
+    /// same files) that change is parked — including as a deletion, which is
+    /// what a rename or delete leaves behind — the fast-forward retried, and our
+    /// version laid back on top, so ours wins on any overlap without a merge
+    /// ever running.
+    pub fn publish_worktree(&self, pathspecs: &[String], message: &str) -> Result<PublishOutcome> {
+        // Only rebase when the remote has actually moved. With no upstream, or
+        // when we are already level with it, the change commits straight on top
+        // and the push is a fast-forward regardless.
+        if let Ok(upstream) = Git::upstream_ref(&self.dir) {
+            if Git::rev_parse(&self.dir, "HEAD")? != Git::rev_parse(&self.dir, &upstream)? {
+                self.rebase_worktree_onto(&upstream, pathspecs)?;
+            }
+        }
+        self.publish(pathspecs, message)
+    }
+
+    /// Fast-forward onto `upstream` while keeping our uncommitted changes to
+    /// `pathspecs`, ours winning on any path both sides touched.
+    ///
+    /// The changes — including deletions, which a rename or delete leaves — are
+    /// parked and set aside first, so a plain fast-forward can run (an unstaged
+    /// deletion does not block `merge --ff-only`; git would silently resurrect
+    /// the file). Our version is then laid back on top. Unrelated uncommitted
+    /// work that blocks the fast-forward is parked around it too, exactly as
+    /// sync does, so one draft cannot wedge a publish.
+    fn rebase_worktree_onto(&self, upstream: &str, pathspecs: &[String]) -> Result<()> {
+        let diverged = || Error::RegistrySync {
+            name: "personal".into(),
+            message: "The library has local commits the registry has not seen.\n\
+                      Run 'akm skills sync' first, then retry."
+                .into(),
+        };
+
+        // 1. Set our change to these paths aside, then clean the paths back to
+        //    HEAD so nothing under them can block the fast-forward.
+        let refs: Vec<&str> = pathspecs.iter().map(String::as_str).collect();
+        let mine: Vec<Parked> = self
+            .changed_paths_under(pathspecs)?
+            .iter()
+            .map(|rel| Parked::take(&self.dir, rel))
+            .collect::<Result<_>>()?;
+        Git::restore_path(&self.dir, &refs)?;
+        Git::clean_path(&self.dir, &refs)?;
+
+        // 2. Fast-forward. Unrelated work that blocks it is parked and restored.
+        let outcome = match Git::merge_ff_only(&self.dir, upstream)? {
+            outcome @ (MergeOutcome::UpToDate | MergeOutcome::FastForwarded) => outcome,
+            MergeOutcome::Blocked { paths } => {
+                let other: Vec<Parked> = paths
+                    .iter()
+                    .map(|rel| Parked::take(&self.dir, rel))
+                    .collect::<Result<_>>()?;
+                let orefs: Vec<&str> = paths.iter().map(String::as_str).collect();
+                Git::restore_path(&self.dir, &orefs)?;
+                Git::clean_path(&self.dir, &orefs)?;
+                let outcome = Git::merge_ff_only(&self.dir, upstream)?;
+                for entry in &other {
+                    entry.restore(&self.dir)?;
+                }
+                outcome
+            }
+            other => other,
+        };
+
+        // 3. Lay our change back on top — ours wins on any overlap. It is
+        //    restored whatever happened, so a failed retry never costs the edit.
+        for entry in &mine {
+            entry.restore(&self.dir)?;
+        }
+
+        match outcome {
+            MergeOutcome::UpToDate | MergeOutcome::FastForwarded => Ok(()),
+            _ => Err(diverged()),
+        }
+    }
+
+    /// Paths under `pathspecs` that differ from HEAD in the working tree,
+    /// including untracked additions and deletions.
+    fn changed_paths_under(&self, pathspecs: &[String]) -> Result<Vec<String>> {
+        let under = |path: &str| {
+            pathspecs
+                .iter()
+                .any(|ps| path == ps || path.starts_with(&format!("{ps}/")))
+        };
+        Ok(Git::status_porcelain(&self.dir)?
+            .into_iter()
+            .filter(|e| under(&e.path))
+            .map(|e| e.path)
+            .collect())
+    }
+
     /// Push, reporting a failure as a registry-sync error.
     fn push(&self) -> Result<()> {
         Git::push(&self.dir).map_err(|e| Error::RegistrySync {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,7 +4,8 @@
 //! when the TUI starts and passed to each view. Views read from `App`
 //! and may mutate it (e.g., toggling core flag updates the library).
 
-use crate::error::Result;
+use crate::commands::skills::{delete, rename};
+use crate::error::{Error, Result};
 use crate::git::Git;
 use crate::library::drift::DriftReport;
 use crate::library::manifest::Manifest;
@@ -47,6 +48,46 @@ pub struct App {
     pub edited_meta: BTreeSet<String>,
     /// Whether the manifest has been modified and needs saving.
     pub manifest_dirty: bool,
+    /// Library changes made this session that the remote has not seen.
+    ///
+    /// Rename and delete run eagerly against the working tree, but the publish
+    /// prompt reads stdin line-by-line and cannot run inside the raw-mode TUI.
+    /// So each such change is recorded here and offered for publishing once the
+    /// terminal has been restored on exit.
+    pub pending_publish: Vec<PendingPublish>,
+}
+
+/// A library change awaiting a publish offer after the TUI exits.
+#[derive(Debug, Clone)]
+pub struct PendingPublish {
+    /// One-line summary shown to the user (e.g. "Renamed skill 'a' -> 'b'").
+    pub summary: String,
+    /// The paths whose change should be pushed.
+    pub pathspecs: Vec<String>,
+    /// The commit message for the push.
+    pub message: String,
+}
+
+/// Result of a rename attempt in the TUI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenameOutcome {
+    /// The spec was renamed.
+    Renamed,
+    /// The proposed id is not a usable slug; carries the reason.
+    InvalidId(String),
+    /// Another spec already uses the proposed id.
+    Collision,
+    /// The spec to rename was not found.
+    NotFound,
+}
+
+/// Result of a delete attempt in the TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    /// The spec was deleted.
+    Deleted,
+    /// The spec to delete was not found.
+    NotFound,
 }
 
 /// Result of an add-to-manifest operation.
@@ -118,6 +159,7 @@ impl App {
             library_dirty: false,
             edited_meta: BTreeSet::new(),
             manifest_dirty: false,
+            pending_publish: Vec::new(),
         })
     }
 
@@ -238,6 +280,101 @@ impl App {
         self.manifest_ids.remove(spec_id);
         self.manifest_dirty = true;
         Ok(RemoveResult::Removed)
+    }
+
+    /// Rename a spec's id, eagerly, from within the TUI.
+    ///
+    /// Unlike core/manifest toggles this cannot be deferred to exit: it moves
+    /// files and rewrites the index. Deferred edits are flushed first so the
+    /// reload afterwards does not drop them, and the change is queued for a
+    /// publish offer once the terminal is restored.
+    pub fn rename_spec(&mut self, old: &str, new: &str) -> Result<RenameOutcome> {
+        let Some(spec) = self.library.get(old) else {
+            return Ok(RenameOutcome::NotFound);
+        };
+        let spec_type = spec.spec_type;
+        let mut pathspecs = spec_type.pathspecs(old);
+        pathspecs.extend(spec_type.pathspecs(new));
+
+        self.flush_deferred()?;
+
+        match rename::apply(&self.paths, old, new, &self.tool_dirs) {
+            Ok(_) => {}
+            Err(Error::InvalidSpecId { reason, .. }) => {
+                return Ok(RenameOutcome::InvalidId(reason))
+            }
+            Err(Error::SpecAlreadyExists { .. }) => return Ok(RenameOutcome::Collision),
+            Err(Error::SpecNotFound { .. }) => return Ok(RenameOutcome::NotFound),
+            Err(e) => return Err(e),
+        }
+
+        if self.manifest_ids.remove(old) {
+            if let Some(manifest) = &mut self.manifest {
+                manifest.remove(old, Some(spec_type));
+                manifest.add(new, spec_type);
+            }
+            self.manifest_ids.insert(new.to_string());
+            self.manifest_dirty = true;
+        }
+
+        self.reload_library()?;
+        self.pending_publish.push(PendingPublish {
+            summary: format!("Renamed {spec_type} '{old}' -> '{new}'"),
+            pathspecs,
+            message: format!("refactor: rename {spec_type} '{old}' -> '{new}'"),
+        });
+        Ok(RenameOutcome::Renamed)
+    }
+
+    /// Delete a spec from the library, eagerly, from within the TUI.
+    ///
+    /// See [`Self::rename_spec`] for why this cannot be deferred to exit.
+    pub fn delete_spec(&mut self, id: &str) -> Result<DeleteOutcome> {
+        let Some(spec) = self.library.get(id) else {
+            return Ok(DeleteOutcome::NotFound);
+        };
+        let spec_type = spec.spec_type;
+        let pathspecs = spec.pathspecs();
+
+        self.flush_deferred()?;
+
+        match delete::apply(&self.paths, id, &self.tool_dirs) {
+            Ok(()) => {}
+            Err(Error::SpecNotFound { .. }) => return Ok(DeleteOutcome::NotFound),
+            Err(e) => return Err(e),
+        }
+
+        if self.manifest_ids.remove(id) {
+            if let Some(manifest) = &mut self.manifest {
+                manifest.remove(id, Some(spec_type));
+            }
+            self.manifest_dirty = true;
+        }
+
+        self.reload_library()?;
+        self.pending_publish.push(PendingPublish {
+            summary: format!("Deleted {spec_type} '{id}'"),
+            pathspecs,
+            message: format!("chore: remove {spec_type} '{id}'"),
+        });
+        Ok(DeleteOutcome::Deleted)
+    }
+
+    /// Persist any deferred edits (core toggles, metadata, manifest) and clear
+    /// the dirty flags, so a subsequent reload from disk keeps them.
+    fn flush_deferred(&mut self) -> Result<()> {
+        self.save_if_dirty()?;
+        self.library_dirty = false;
+        self.edited_meta.clear();
+        self.manifest_dirty = false;
+        Ok(())
+    }
+
+    /// Reload the library index and drift after an eager on-disk change.
+    fn reload_library(&mut self) -> Result<()> {
+        self.library = Library::load_from(&self.paths.library_json())?;
+        self.drift = DriftReport::compute(&self.paths.library_dir()).unwrap_or_default();
+        Ok(())
     }
 
     /// Save any dirty state to disk and rebuild symlinks. Called on TUI exit.

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -17,6 +17,8 @@
 //! - `e` → edit metadata (tags, triggers)
 //! - `a` → add to current project manifest
 //! - `r` → remove from current project manifest
+//! - `R` → rename the spec's id (its slug)
+//! - `D` → delete the spec from the library
 //! - `q` → quit
 //! - `Esc` → clear the search filter (never quits)
 //! - `↑`/`↓` or `j`/`k` → navigate
@@ -30,14 +32,16 @@
 //! - `↑`/`↓` → navigate
 //! - `Ctrl+C` → exit immediately
 
+use crate::config::Config;
 use crate::error::Result;
 use crate::library::spec::SpecType;
 use crate::library::tool_dirs::ToolDirs;
 use crate::paths::Paths;
-use crate::tui::app::{AddResult, App, RemoveResult};
+use crate::tui::app::{AddResult, App, DeleteOutcome, RemoveResult, RenameOutcome};
 use crate::tui::detail;
 use crate::tui::edit as tui_edit;
 use crate::tui::event::{self, Event};
+use crate::tui::input::TextInput;
 use crate::tui::theme;
 use crate::tui::{self, EventOutcome, Term, ViewSwitch};
 
@@ -58,6 +62,10 @@ enum Mode {
     Normal,
     /// Letters are appended to the search query.
     Search,
+    /// Typing the new id for the spec being renamed.
+    Rename,
+    /// Awaiting `y`/`n` to confirm deleting the spec.
+    ConfirmDelete,
 }
 
 /// State for the list view.
@@ -76,6 +84,10 @@ struct ListView {
     type_filter: Option<SpecType>,
     /// Status message shown briefly after an action (e.g., "✓ Added to manifest").
     status_message: Option<String>,
+    /// The id targeted by an in-progress rename/delete (the modal target).
+    pending_id: Option<String>,
+    /// Text field for the new id while renaming.
+    rename_input: TextInput,
 }
 
 impl ListView {
@@ -96,6 +108,8 @@ impl ListView {
             tag_filter,
             type_filter,
             status_message: None,
+            pending_id: None,
+            rename_input: TextInput::default(),
         }
     }
 
@@ -188,7 +202,27 @@ pub fn run(
         eprintln!("Warning: failed to save changes: {save_err}");
     }
 
+    // Eager rename/delete changes could not be published inside the raw-mode
+    // TUI. Now that the terminal is restored, offer them on the normal terminal.
+    if result.is_ok() && !app.pending_publish.is_empty() {
+        offer_pending_publishes(paths, &app);
+    }
+
     result
+}
+
+/// After the TUI exits, offer to publish the rename/delete changes it made.
+fn offer_pending_publishes(paths: &Paths, app: &App) {
+    let config = Config::load(paths).unwrap_or_default();
+    for change in &app.pending_publish {
+        println!("{}", change.summary);
+        crate::commands::skills::publish::offer_pathspecs(
+            paths,
+            &config,
+            &change.pathspecs,
+            &change.message,
+        );
+    }
 }
 
 /// The main event loop for the list view.
@@ -232,6 +266,8 @@ fn handle_list_key(key: KeyEvent, app: &mut App, view: &mut ListView) -> Result<
             handle_search_key(key, view);
             Ok(EventOutcome::Continue)
         }
+        Mode::Rename => handle_rename_key(key, app, view),
+        Mode::ConfirmDelete => handle_confirm_delete_key(key, app, view),
     }
 }
 
@@ -314,7 +350,93 @@ fn handle_normal_key(key: KeyEvent, app: &mut App, view: &mut ListView) -> Resul
             }
         }
 
+        KeyCode::Char('R') => {
+            if let Some(id) = view.selected_id() {
+                let id = id.to_string();
+                view.rename_input = TextInput::new(&id);
+                view.pending_id = Some(id);
+                view.mode = Mode::Rename;
+            }
+        }
+        KeyCode::Char('D') => {
+            if let Some(id) = view.selected_id() {
+                view.pending_id = Some(id.to_string());
+                view.mode = Mode::ConfirmDelete;
+            }
+        }
+
         _ => {}
+    }
+
+    Ok(EventOutcome::Continue)
+}
+
+/// Handle a key event while typing the new id for a rename.
+///
+/// `Enter` commits, `Esc` cancels. A rejected id (bad slug or collision) keeps
+/// the field open so it can be corrected; success returns to normal mode.
+fn handle_rename_key(key: KeyEvent, app: &mut App, view: &mut ListView) -> Result<EventOutcome> {
+    if event::is_escape(&key) {
+        view.mode = Mode::Normal;
+        view.pending_id = None;
+        return Ok(EventOutcome::Continue);
+    }
+
+    match key.code {
+        KeyCode::Enter => {
+            let (Some(old), new) = (view.pending_id.clone(), view.rename_input.value()) else {
+                view.mode = Mode::Normal;
+                return Ok(EventOutcome::Continue);
+            };
+            if new == old {
+                view.mode = Mode::Normal;
+                view.pending_id = None;
+                return Ok(EventOutcome::Continue);
+            }
+            match app.rename_spec(&old, &new)? {
+                RenameOutcome::Renamed => {
+                    view.status_message = Some(format!("Renamed '{old}' -> '{new}'"));
+                    view.mode = Mode::Normal;
+                    view.pending_id = None;
+                }
+                RenameOutcome::InvalidId(reason) => {
+                    view.status_message = Some(format!("Invalid id: {reason}"));
+                }
+                RenameOutcome::Collision => {
+                    view.status_message = Some(format!("'{new}' already exists"));
+                }
+                RenameOutcome::NotFound => {
+                    view.status_message = Some(format!("Spec not found: {old}"));
+                    view.mode = Mode::Normal;
+                    view.pending_id = None;
+                }
+            }
+        }
+        KeyCode::Backspace => view.rename_input.backspace(),
+        KeyCode::Left => view.rename_input.left(),
+        KeyCode::Right => view.rename_input.right(),
+        KeyCode::Char(c) => view.rename_input.insert(c),
+        _ => {}
+    }
+
+    Ok(EventOutcome::Continue)
+}
+
+/// Handle the `y`/`n` confirmation before deleting a spec.
+fn handle_confirm_delete_key(
+    key: KeyEvent,
+    app: &mut App,
+    view: &mut ListView,
+) -> Result<EventOutcome> {
+    let id = view.pending_id.clone();
+    view.mode = Mode::Normal;
+    view.pending_id = None;
+
+    if let (KeyCode::Char('y') | KeyCode::Char('Y'), Some(id)) = (key.code, id) {
+        match app.delete_spec(&id)? {
+            DeleteOutcome::Deleted => view.status_message = Some(format!("Deleted '{id}'")),
+            DeleteOutcome::NotFound => view.status_message = Some(format!("Spec not found: {id}")),
+        }
     }
 
     Ok(EventOutcome::Continue)
@@ -354,7 +476,7 @@ fn render_list(frame: &mut Frame, app: &App, view: &mut ListView) {
         ])
         .split(frame.area());
 
-    render_search_bar(frame, chunks[0], view.mode, &view.search_query);
+    render_prompt_bar(frame, chunks[0], view);
     render_table(frame, chunks[1], app, view);
 
     if let Some(ref msg) = view.status_message {
@@ -363,6 +485,32 @@ fn render_list(frame: &mut Frame, app: &App, view: &mut ListView) {
     }
 
     render_help_bar(frame, chunks[3], view.mode, !app.drift.is_clean());
+}
+
+/// Render the top bar: the search field, or the rename/confirm-delete prompt.
+fn render_prompt_bar(frame: &mut Frame, area: Rect, view: &ListView) {
+    match view.mode {
+        Mode::Rename => {
+            let target = view.pending_id.as_deref().unwrap_or("");
+            let line = Line::from(vec![
+                Span::styled(format!(" Rename {target} -> "), theme::SEARCH_BAR),
+                Span::raw(view.rename_input.value()),
+                Span::styled("█", theme::SEARCH_BAR),
+            ]);
+            frame.render_widget(Paragraph::new(line).style(theme::SEARCH_BAR), area);
+        }
+        Mode::ConfirmDelete => {
+            let target = view.pending_id.as_deref().unwrap_or("");
+            let line = Line::from(vec![Span::styled(
+                format!(" Delete '{target}' from the library? [y/N]"),
+                theme::WARNING,
+            )]);
+            frame.render_widget(Paragraph::new(line), area);
+        }
+        Mode::Normal | Mode::Search => {
+            render_search_bar(frame, area, view.mode, &view.search_query)
+        }
+    }
 }
 
 /// Render the search/filter bar.
@@ -385,6 +533,8 @@ fn render_search_bar(frame: &mut Frame, area: Rect, mode: Mode, query: &str) {
             Span::raw(query),
             Span::styled("  [filtered]", theme::DIM),
         ]),
+        // The modal modes render their own prompt via `render_prompt_bar`.
+        (Mode::Rename, _) | (Mode::ConfirmDelete, _) => Line::from(""),
     };
     let para = Paragraph::new(text).style(theme::SEARCH_BAR);
     frame.render_widget(para, area);
@@ -461,6 +611,8 @@ fn render_help_bar(frame: &mut Frame, area: Rect, mode: Mode, show_drift_legend:
             ("e", " edit  "),
             ("a", " add  "),
             ("r", " remove  "),
+            ("R", " rename  "),
+            ("D", " delete  "),
             ("/", " search  "),
             ("Esc", " clear filter  "),
             ("q", " quit"),
@@ -472,6 +624,12 @@ fn render_help_bar(frame: &mut Frame, area: Rect, mode: Mode, show_drift_legend:
             ("Enter/Esc", " done  "),
             ("Ctrl+C", " quit"),
         ],
+        Mode::Rename => &[
+            (" type", " new id  "),
+            ("Enter", " confirm  "),
+            ("Esc", " cancel"),
+        ],
+        Mode::ConfirmDelete => &[("y", " delete  "), ("n/Esc", " cancel")],
     };
     let help_text = Line::from(
         pairs
@@ -553,6 +711,98 @@ mod tests {
         let tool_dirs = ToolDirs::builtin(tmp.path());
         let app = App::new(paths, tool_dirs).unwrap();
         (app, tmp)
+    }
+
+    /// An App whose specs actually exist on disk, so rename/delete (which move
+    /// and remove files) can run. Returns the App and its temp-dir guard.
+    fn test_app_on_disk() -> (App, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = Paths::from_roots(tmp.path(), tmp.path(), tmp.path(), tmp.path());
+        let library_dir = paths.library_dir();
+
+        for id in ["git-commit", "git-worktrees"] {
+            let dir = library_dir.join("skills").join(id);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("SKILL.md"),
+                format!("---\nname: {id}\ndescription: a test skill\n---\nBody"),
+            )
+            .unwrap();
+        }
+        crate::library::libgen::generate(&library_dir, &paths.library_json()).unwrap();
+
+        let tool_dirs = ToolDirs::builtin(tmp.path());
+        let app = App::new(paths, tool_dirs).unwrap();
+        (app, tmp)
+    }
+
+    /// A normal-mode view over `app`, cursor on the first row.
+    fn normal_view(app: &mut App) -> ListView {
+        let mut view = ListView::new(None, None, None);
+        view.update_visible(app);
+        view
+    }
+
+    #[test]
+    fn capital_r_opens_rename_prefilled_with_the_id() {
+        let (mut app, _tmp) = test_app_on_disk();
+        let mut view = normal_view(&mut app);
+        handle_list_key(ch('R'), &mut app, &mut view).unwrap();
+        assert_eq!(view.mode, Mode::Rename);
+        assert_eq!(view.pending_id.as_deref(), Some("git-commit"));
+        assert_eq!(view.rename_input.value(), "git-commit");
+    }
+
+    #[test]
+    fn committing_a_rename_moves_the_spec_and_queues_a_publish() {
+        let (mut app, _tmp) = test_app_on_disk();
+        let mut view = normal_view(&mut app);
+        handle_list_key(ch('R'), &mut app, &mut view).unwrap();
+        view.rename_input = TextInput::new("git-renamed");
+        handle_list_key(key(KeyCode::Enter), &mut app, &mut view).unwrap();
+
+        assert_eq!(view.mode, Mode::Normal);
+        assert!(app.library.get("git-commit").is_none());
+        assert!(app.library.get("git-renamed").is_some());
+        assert_eq!(app.pending_publish.len(), 1);
+    }
+
+    #[test]
+    fn rename_collision_keeps_the_field_open() {
+        let (mut app, _tmp) = test_app_on_disk();
+        let mut view = normal_view(&mut app);
+        handle_list_key(ch('R'), &mut app, &mut view).unwrap();
+        view.rename_input = TextInput::new("git-worktrees");
+        handle_list_key(key(KeyCode::Enter), &mut app, &mut view).unwrap();
+
+        // Still renaming, both specs intact.
+        assert_eq!(view.mode, Mode::Rename);
+        assert!(app.library.get("git-commit").is_some());
+        assert!(app.pending_publish.is_empty());
+    }
+
+    #[test]
+    fn capital_d_then_y_deletes_and_queues_a_publish() {
+        let (mut app, _tmp) = test_app_on_disk();
+        let mut view = normal_view(&mut app);
+        handle_list_key(ch('D'), &mut app, &mut view).unwrap();
+        assert_eq!(view.mode, Mode::ConfirmDelete);
+
+        handle_list_key(ch('y'), &mut app, &mut view).unwrap();
+        assert_eq!(view.mode, Mode::Normal);
+        assert!(app.library.get("git-commit").is_none());
+        assert_eq!(app.pending_publish.len(), 1);
+    }
+
+    #[test]
+    fn delete_cancelled_leaves_the_spec() {
+        let (mut app, _tmp) = test_app_on_disk();
+        let mut view = normal_view(&mut app);
+        handle_list_key(ch('D'), &mut app, &mut view).unwrap();
+        handle_list_key(ch('n'), &mut app, &mut view).unwrap();
+        assert_eq!(view.mode, Mode::Normal);
+        assert!(app.library.get("git-commit").is_some());
+        assert!(app.pending_publish.is_empty());
     }
 
     /// A view already filtered to "git" and back in normal mode.

--- a/tests/help_test.rs
+++ b/tests/help_test.rs
@@ -38,6 +38,23 @@ fn test_skills_help_output_snapshot() {
     );
 }
 
+/// Rename and delete are destructive/structural, so their contract — argument
+/// order and `delete`'s `--force` — is pinned.
+#[test]
+fn test_rename_delete_help_snapshots() {
+    for command in ["rename", "delete"] {
+        let output = cargo_bin_cmd!("akm")
+            .args(["skills", command, "--help"])
+            .output()
+            .unwrap();
+
+        insta::assert_snapshot!(
+            format!("{command}_help_output"),
+            String::from_utf8_lossy(&output.stdout).to_string()
+        );
+    }
+}
+
 /// The drift commands are the user-facing half of the sync rework, so their
 /// contract is pinned. `publish` is on the list because its id is optional —
 /// omitting it publishes everything pending, and that has to stay visible.

--- a/tests/skills_delete_test.rs
+++ b/tests/skills_delete_test.rs
@@ -1,0 +1,138 @@
+//! Integration tests for `akm skills delete`.
+
+use akm::commands::skills::delete;
+use akm::error::Error;
+use akm::library::libgen;
+use akm::library::local::LocalOverrides;
+use akm::library::tool_dirs::ToolDirs;
+use akm::library::Library;
+use akm::paths::Paths;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn test_paths(tmp: &TempDir) -> Paths {
+    Paths::from_roots(
+        &tmp.path().join("data"),
+        &tmp.path().join("config"),
+        &tmp.path().join("cache"),
+        &tmp.path().join("home"),
+    )
+}
+
+fn test_tool_dirs(tmp: &TempDir) -> ToolDirs {
+    ToolDirs::builtin(&tmp.path().join("home"))
+}
+
+fn write_skill(library_dir: &Path, id: &str) {
+    let dir = library_dir.join("skills").join(id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {id}\ndescription: a test skill\n---\nBody"),
+    )
+    .unwrap();
+}
+
+fn write_agent(library_dir: &Path, id: &str) {
+    let dir = library_dir.join("agents");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join(format!("{id}.md")),
+        format!("---\nname: {id}\ndescription: a test agent\n---\nBody"),
+    )
+    .unwrap();
+}
+
+fn regen(paths: &Paths) {
+    libgen::generate(&paths.library_dir(), &paths.library_json()).unwrap();
+}
+
+#[test]
+fn delete_removes_a_skill_directory() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "doomed");
+    write_skill(&paths.library_dir(), "keeper");
+    regen(&paths);
+
+    delete::apply(&paths, "doomed", &tool_dirs).unwrap();
+
+    assert!(!paths.library_dir().join("skills").join("doomed").exists());
+    assert!(paths.library_dir().join("skills").join("keeper").exists());
+
+    let library = Library::load(&paths).unwrap();
+    assert!(library.get("doomed").is_none());
+    assert!(library.get("keeper").is_some());
+}
+
+#[test]
+fn delete_removes_agent_markdown_and_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    let agents = paths.library_dir().join("agents");
+    write_agent(&paths.library_dir(), "bot");
+    std::fs::write(
+        agents.join("bot.akm.json"),
+        r#"{"name":"Bot","description":"d","tags":[],"core":false,"triggers":{}}"#,
+    )
+    .unwrap();
+    regen(&paths);
+
+    delete::apply(&paths, "bot", &tool_dirs).unwrap();
+
+    assert!(!agents.join("bot.md").exists());
+    assert!(!agents.join("bot.akm.json").exists());
+}
+
+#[test]
+fn delete_clears_the_local_core_override() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "doomed");
+    regen(&paths);
+
+    let mut overrides = LocalOverrides::default();
+    overrides.core.insert("doomed".to_string(), true);
+    overrides.save_to(&paths.local_json()).unwrap();
+
+    delete::apply(&paths, "doomed", &tool_dirs).unwrap();
+
+    let overrides = LocalOverrides::load_from(&paths.local_json()).unwrap();
+    assert_eq!(overrides.core.get("doomed"), None);
+}
+
+#[test]
+fn delete_fails_for_missing_spec() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "alpha");
+    regen(&paths);
+
+    let err = delete::apply(&paths, "ghost", &tool_dirs).unwrap_err();
+    assert!(matches!(err, Error::SpecNotFound { .. }));
+}
+
+/// The `run` entry point refuses to delete in a non-TTY without `--force`.
+/// Tests run without a controlling terminal, so this exercises that path.
+#[test]
+fn delete_requires_force_without_a_tty() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "alpha");
+    regen(&paths);
+    let config = akm::config::Config::default();
+
+    let err = delete::run(&paths, &config, "alpha", false, &tool_dirs).unwrap_err();
+    assert!(matches!(err, Error::ConfirmationRequired { .. }));
+    // The spec is untouched.
+    assert!(paths.library_dir().join("skills").join("alpha").exists());
+
+    // With --force it goes through even without a TTY.
+    delete::run(&paths, &config, "alpha", true, &tool_dirs).unwrap();
+    assert!(!paths.library_dir().join("skills").join("alpha").exists());
+}

--- a/tests/skills_publish_test.rs
+++ b/tests/skills_publish_test.rs
@@ -144,6 +144,38 @@ impl Env {
         publish::run(&self.paths, &self.config, id, false)
     }
 
+    /// Publish an explicit set of working-tree paths, as rename/delete do.
+    ///
+    /// Mirrors `publish::publish_pathspecs`, which the TTY-gated offer prompt
+    /// keeps out of reach in tests: refresh, then land on top of the remote.
+    fn publish_worktree(&self, pathspecs: &[&str]) -> akm::error::Result<()> {
+        let registry = Registry::new(
+            self.config.registry_url().unwrap(),
+            self.paths.library_dir(),
+        );
+        registry.refresh()?;
+        let owned: Vec<String> = pathspecs.iter().map(|s| s.to_string()).collect();
+        registry.publish_worktree(&owned, "test: worktree publish")?;
+        Ok(())
+    }
+
+    /// Whether the registry still holds `rel`, as seen from the other checkout.
+    fn remote_has(&self, rel: &str) -> bool {
+        git(&self.other, &["pull", "--quiet", "--ff-only"]);
+        self.other.join(rel).exists()
+    }
+
+    /// The library's working tree is clean and level with the remote — i.e. the
+    /// publish landed as a fast-forward, leaving no diverged local commit.
+    fn library_is_level_with_remote(&self) -> bool {
+        let dir = self.paths.library_dir();
+        let status = git(&dir, &["status", "--porcelain"]);
+        let local = git(&dir, &["rev-parse", "HEAD"]);
+        git(&dir, &["fetch", "--quiet"]);
+        let remote = git(&dir, &["rev-parse", "@{u}"]);
+        status.is_empty() && local == remote
+    }
+
     /// What the registry holds for `rel`, as seen from the other checkout.
     fn remote_content(&self, rel: &str) -> String {
         git(&self.other, &["pull", "--quiet", "--ff-only"]);
@@ -353,4 +385,85 @@ fn publishing_an_unchanged_spec_does_nothing() {
     git(&env.other, &["fetch", "--quiet"]);
     let count = git(&env.other, &["rev-list", "--count", "origin/main"]);
     assert_eq!(count, "1");
+}
+
+// =============================================================================
+// rename / delete land on top of a remote that moved on — never bare-git detours
+// =============================================================================
+
+/// A rename published while the remote advanced on a *different* spec must
+/// fast-forward over that change and land cleanly, not fork history.
+#[test]
+fn renaming_over_a_moved_remote_lands_and_keeps_their_other_changes() {
+    let env = Env::new();
+    env.sync();
+    let ld = env.paths.library_dir();
+
+    std::fs::rename(ld.join("skills/alpha"), ld.join("skills/alpha-v2")).unwrap();
+    env.push_from_other("skills/beta/SKILL.md", &skill_md("beta", "their beta"));
+
+    env.publish_worktree(&["skills/alpha", "skills/alpha-v2"])
+        .unwrap();
+
+    assert!(env.remote_has("skills/alpha-v2/SKILL.md"));
+    assert!(!env.remote_has("skills/alpha/SKILL.md"));
+    assert!(env
+        .remote_content("skills/beta/SKILL.md")
+        .contains("their beta"));
+    assert!(env.library_is_level_with_remote());
+}
+
+/// A rename published while the remote changed the *same* spec: our rename wins
+/// (old id gone, new id holds our content), with no conflict markers.
+#[test]
+fn renaming_over_a_diverged_remote_keeps_the_local_version() {
+    let env = Env::new();
+    env.sync();
+    let ld = env.paths.library_dir();
+
+    std::fs::rename(ld.join("skills/alpha"), ld.join("skills/alpha-v2")).unwrap();
+    env.push_from_other("skills/alpha/SKILL.md", &skill_md("alpha", "THEIR ALPHA"));
+
+    env.publish_worktree(&["skills/alpha", "skills/alpha-v2"])
+        .unwrap();
+
+    let v2 = env.remote_content("skills/alpha-v2/SKILL.md");
+    assert!(v2.contains("v1"), "our content should win, got: {v2}");
+    assert!(!v2.contains("<<<<<<<"));
+    assert!(!env.remote_has("skills/alpha/SKILL.md"));
+    assert!(env.library_is_level_with_remote());
+}
+
+/// A delete published while the remote advanced on a different spec lands as a
+/// fast-forward and preserves the other change.
+#[test]
+fn deleting_over_a_moved_remote_lands_and_keeps_their_other_changes() {
+    let env = Env::new();
+    env.sync();
+
+    std::fs::remove_dir_all(env.library_file("skills/alpha")).unwrap();
+    env.push_from_other("skills/beta/SKILL.md", &skill_md("beta", "their beta"));
+
+    env.publish_worktree(&["skills/alpha"]).unwrap();
+
+    assert!(!env.remote_has("skills/alpha/SKILL.md"));
+    assert!(env
+        .remote_content("skills/beta/SKILL.md")
+        .contains("their beta"));
+    assert!(env.library_is_level_with_remote());
+}
+
+/// A delete wins over a concurrent edit of the same spec: the remote drops it.
+#[test]
+fn deleting_over_a_diverged_remote_removes_the_spec() {
+    let env = Env::new();
+    env.sync();
+
+    std::fs::remove_dir_all(env.library_file("skills/alpha")).unwrap();
+    env.push_from_other("skills/alpha/SKILL.md", &skill_md("alpha", "THEIR ALPHA"));
+
+    env.publish_worktree(&["skills/alpha"]).unwrap();
+
+    assert!(!env.remote_has("skills/alpha/SKILL.md"));
+    assert!(env.library_is_level_with_remote());
 }

--- a/tests/skills_rename_test.rs
+++ b/tests/skills_rename_test.rs
@@ -1,0 +1,166 @@
+//! Integration tests for `akm skills rename`.
+
+use akm::commands::skills::rename;
+use akm::error::Error;
+use akm::library::libgen;
+use akm::library::local::LocalOverrides;
+use akm::library::spec::SpecType;
+use akm::library::tool_dirs::ToolDirs;
+use akm::library::Library;
+use akm::paths::Paths;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn test_paths(tmp: &TempDir) -> Paths {
+    Paths::from_roots(
+        &tmp.path().join("data"),
+        &tmp.path().join("config"),
+        &tmp.path().join("cache"),
+        &tmp.path().join("home"),
+    )
+}
+
+fn test_tool_dirs(tmp: &TempDir) -> ToolDirs {
+    ToolDirs::builtin(&tmp.path().join("home"))
+}
+
+fn write_skill(library_dir: &Path, id: &str) {
+    let dir = library_dir.join("skills").join(id);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {id}\ndescription: a test skill\n---\nBody"),
+    )
+    .unwrap();
+}
+
+fn write_agent(library_dir: &Path, id: &str) {
+    let dir = library_dir.join("agents");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join(format!("{id}.md")),
+        format!("---\nname: {id}\ndescription: a test agent\n---\nBody"),
+    )
+    .unwrap();
+}
+
+/// Regenerate library.json from whatever is currently on disk.
+fn regen(paths: &Paths) {
+    libgen::generate(&paths.library_dir(), &paths.library_json()).unwrap();
+}
+
+#[test]
+fn rename_moves_a_skill_directory() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "old-skill");
+    regen(&paths);
+
+    let spec_type = rename::apply(&paths, "old-skill", "new-skill", &tool_dirs).unwrap();
+    assert_eq!(spec_type, SpecType::Skill);
+
+    assert!(!paths
+        .library_dir()
+        .join("skills")
+        .join("old-skill")
+        .exists());
+    assert!(paths
+        .library_dir()
+        .join("skills")
+        .join("new-skill")
+        .join("SKILL.md")
+        .is_file());
+
+    let library = Library::load(&paths).unwrap();
+    assert!(library.get("old-skill").is_none());
+    assert!(library.get("new-skill").is_some());
+}
+
+#[test]
+fn rename_moves_agent_markdown_and_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    let agents = paths.library_dir().join("agents");
+    write_agent(&paths.library_dir(), "old-agent");
+    std::fs::write(
+        agents.join("old-agent.akm.json"),
+        r#"{"name":"Old","description":"d","tags":[],"core":false,"triggers":{}}"#,
+    )
+    .unwrap();
+    regen(&paths);
+
+    rename::apply(&paths, "old-agent", "new-agent", &tool_dirs).unwrap();
+
+    assert!(!agents.join("old-agent.md").exists());
+    assert!(!agents.join("old-agent.akm.json").exists());
+    assert!(agents.join("new-agent.md").is_file());
+    assert!(agents.join("new-agent.akm.json").is_file());
+}
+
+#[test]
+fn rename_rejects_collision_with_existing_spec() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "alpha");
+    write_skill(&paths.library_dir(), "beta");
+    regen(&paths);
+
+    let err = rename::apply(&paths, "alpha", "beta", &tool_dirs).unwrap_err();
+    assert!(matches!(err, Error::SpecAlreadyExists { .. }));
+    // Nothing moved.
+    assert!(paths.library_dir().join("skills").join("alpha").exists());
+}
+
+#[test]
+fn rename_rejects_invalid_new_id() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "alpha");
+    regen(&paths);
+
+    let err = rename::apply(&paths, "alpha", "a/b", &tool_dirs).unwrap_err();
+    assert!(matches!(err, Error::InvalidSpecId { .. }));
+}
+
+#[test]
+fn rename_fails_for_missing_spec() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "alpha");
+    regen(&paths);
+
+    let err = rename::apply(&paths, "ghost", "phantom", &tool_dirs).unwrap_err();
+    assert!(matches!(err, Error::SpecNotFound { .. }));
+}
+
+#[test]
+fn rename_carries_the_local_core_override() {
+    let tmp = TempDir::new().unwrap();
+    let paths = test_paths(&tmp);
+    let tool_dirs = test_tool_dirs(&tmp);
+    write_skill(&paths.library_dir(), "old-skill");
+    regen(&paths);
+
+    // This machine has flipped the skill's core on, deviating from the default.
+    let mut overrides = LocalOverrides::default();
+    overrides.core.insert("old-skill".to_string(), true);
+    overrides.save_to(&paths.local_json()).unwrap();
+
+    rename::apply(&paths, "old-skill", "new-skill", &tool_dirs).unwrap();
+
+    let overrides = LocalOverrides::load_from(&paths.local_json()).unwrap();
+    assert_eq!(overrides.core.get("old-skill"), None);
+    assert_eq!(overrides.core.get("new-skill"), Some(&true));
+    assert!(
+        Library::load(&paths)
+            .unwrap()
+            .get("new-skill")
+            .unwrap()
+            .core
+    );
+}

--- a/tests/snapshots/help_test__delete_help_output.snap
+++ b/tests/snapshots/help_test__delete_help_output.snap
@@ -1,0 +1,15 @@
+---
+source: tests/help_test.rs
+expression: "String::from_utf8_lossy(&output.stdout).to_string()"
+---
+Delete a spec from the library (and the personal registry)
+
+Usage: akm skills delete [OPTIONS] <ID>
+
+Arguments:
+  <ID>  Spec ID to delete
+
+Options:
+      --force    Skip the confirmation prompt
+  -h, --help     Print help
+  -V, --version  Print version

--- a/tests/snapshots/help_test__rename_help_output.snap
+++ b/tests/snapshots/help_test__rename_help_output.snap
@@ -1,0 +1,15 @@
+---
+source: tests/help_test.rs
+expression: "String::from_utf8_lossy(&output.stdout).to_string()"
+---
+Rename a spec's id (its slug / directory name)
+
+Usage: akm skills rename <OLD> <NEW>
+
+Arguments:
+  <OLD>  Current spec ID
+  <NEW>  New spec ID
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -18,6 +18,7 @@ Commands:
   import   Import a skill from a GitHub URL into cold storage
   edit     Edit a spec's markdown in $EDITOR
   rename   Rename a spec's id (its slug / directory name)
+  delete   Delete a spec from the library (and the personal registry)
   publish  Publish spec to personal registry
   diff     Show what changed locally and in the registry for a spec
   revert   Discard local changes to a spec

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -17,6 +17,7 @@ Commands:
   promote  Import local skill into cold storage
   import   Import a skill from a GitHub URL into cold storage
   edit     Edit a spec's markdown in $EDITOR
+  rename   Rename a spec's id (its slug / directory name)
   publish  Publish spec to personal registry
   diff     Show what changed locally and in the registry for a spec
   revert   Discard local changes to a spec


### PR DESCRIPTION
## What

Two new skills-library capabilities, each exposed as a **CLI verb** and a **key in the `list` TUI**:

- **`akm skills rename <old> <new>`** — change a spec's id (its slug / directory name), the token a human types to invoke a skill as `/<slug>`. Moves `skills/<old>` → `skills/<new>` (or the agent's `<old>.md` + `<old>.akm.json` pair), regenerates the derived index, carries this machine's core override across, rebuilds core symlinks, and rewrites the current project's manifest entry.
- **`akm skills delete <id> [--force]`** — the destructive counterpart to `remove` (which only unwires a spec from a project manifest). Confirms first (`[y/N]` on a TTY, `--force` otherwise, `ConfirmationRequired` in a non-TTY), takes the files off disk, rebuilds the index and symlinks without the spec, clears its local core override, and drops it from the current manifest.

When a personal registry is configured, both **offer to publish** afterward (mirroring `edit`): rename pushes the old-path deletion + new-path addition; delete pushes the removal.

## TUI

In the `list` view: `R` renames the selected spec (inline text field, prefilled), `D` deletes it (inline `[y/N]`). These run eagerly against the working tree, then reload the in-memory library and drift. Because the publish prompt reads stdin line-by-line it can't run in raw mode, so each change is recorded and the **publish offer appears after you quit the TUI**. Deferred edits (core/metadata/manifest) are flushed before the reload so they aren't lost.

## Divergence-safe publish (no bare-git detours)

Publishing a rename/delete **fast-forwards onto the remote before committing** (`Registry::publish_worktree`), so a remote that moved on since your last sync is landed on top of rather than rejected. The uncommitted change — **including deletions**, which `merge --ff-only` would otherwise silently resurrect — is parked, the paths cleaned back to `HEAD`, the fast-forward run, and our version laid back on top so **ours wins on any overlap**. The user is never dropped into the library to resolve history in git by hand. (This closes the gap where the old plain commit+push left a diverged local commit if another machine had published first.)

## Design decisions (grilled up front)

- `list` view only; **no** status↔list refactor.
- Local op first, then *offer* publish — consistent with `edit`.
- `delete` guarded like `revert` (`--force`, non-TTY `ConfirmationRequired`); `rename` just validates the id.
- Cleanup reaches the current-project manifest + `local.json`.
- A full interactive TUI publish/sync-review screen was considered and **deliberately deferred** as over-engineered for this PR.

## Known limitations (documented)

- Manifests in **other** repositories still reference the old/deleted id — unreachable from here.
- Delete removes the spec from the working tree + HEAD going forward; git history retains it.

## Tests

- `tests/skills_rename_test.rs`, `tests/skills_delete_test.rs` (file moves/removal, collision/invalid-id/missing-spec, local-override carry/clear, non-TTY `--force` gate).
- `tests/skills_publish_test.rs` — rename/delete over a remote that moved on a **different** spec (lands as fast-forward, keeps their change) and the **same** spec (ours wins, old id gone), asserting the library is left level with the remote.
- `src/tui/list.rs` unit tests for the `R`/`D` key flows + pending-publish recording.
- Help snapshots for `rename`/`delete` and the refreshed skills help.

`cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt` all clean.