### PR TITLE
chore(release): 1.0.0-rc6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akm"
-version = "1.0.0-rc5"
+version = "1.0.0-rc6"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akm"
-version = "1.0.0-rc5"
+version = "1.0.0-rc6"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Agent Kit Manager — manage reusable LLM skills, artifacts, and instructions"

--- a/tests/snapshots/update_test__version_output.snap
+++ b/tests/snapshots/update_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/update_test.rs
 expression: stdout.trim()
 ---
-akm 1.0.0-rc5
+akm 1.0.0-rc6


### PR DESCRIPTION
Bump version to 1.0.0-rc6 for release. Follows #50 (interactive menus).