### PR TITLE
feat(artifacts): copy selected path to clipboard with `y`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,10 @@ akm artifacts sync               # bidirectional git sync
 With no subcommand on a terminal, `akm artifacts` opens a two-pane explorer:
 a lazily-expanding tree on the left, a live plain-text preview on the right.
 `Enter` on a file opens it in `$EDITOR` and returns; dirs expand with `→`/`Enter`
-and collapse with `←`. Non-interactive or `--plain` prints the box-drawing tree
-instead — dirs first, newest date-prefixed file on top, `.git` hidden.
+and collapse with `←`. `y` copies the selected entry's absolute path to the
+clipboard (via OSC 52) so you can paste it straight into an agent. Non-interactive
+or `--plain` prints the box-drawing tree instead — dirs first, newest
+date-prefixed file on top, `.git` hidden.
 
 ### Instructions
 

--- a/src/tui/artifacts.rs
+++ b/src/tui/artifacts.rs
@@ -3,9 +3,11 @@
 //!
 //! Left pane: a lazily-expanding directory tree. Right pane: a live plain-text
 //! preview of the selected file. `Enter`/`o` on a file drops to `$EDITOR` and
-//! comes back (see [`crate::tui::edit_file_in_terminal`]). There are no git
-//! side effects here — committing is owned by session exit / `akm artifacts
-//! sync`.
+//! comes back (see [`crate::tui::edit_file_in_terminal`]). `y` copies the
+//! selected entry's absolute path to the clipboard (see
+//! [`crate::tui::copy_to_clipboard`]) so it can be pasted straight into an
+//! agent. There are no git side effects here — committing is owned by session
+//! exit / `akm artifacts sync`.
 //!
 //! Structure mirrors [`crate::tui::list`]: a pure state machine
 //! ([`Explorer`] and its methods) that is unit-tested with synthetic key
@@ -22,6 +24,7 @@ use crate::tui::{self, Term};
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 use ratatui::Frame;
@@ -43,8 +46,9 @@ struct Explorer {
     rows: Vec<TreeNode>,
     /// Index of the highlighted row.
     selected: usize,
-    /// Inline status (e.g. an editor spawn failure), cleared on the next key.
-    status: Option<String>,
+    /// Inline status (e.g. a copy confirmation or an editor spawn failure),
+    /// with the style to render it in. Cleared on the next key.
+    status: Option<(String, Style)>,
 }
 
 /// What a handled key asks the loop to do. Pure — no terminal, so the state
@@ -57,6 +61,8 @@ enum Action {
     Exit,
     /// Suspend and open this file in `$EDITOR`.
     OpenFile(PathBuf),
+    /// Copy this absolute path to the clipboard (OSC 52, owned by the loop).
+    CopyPath(PathBuf),
 }
 
 impl Explorer {
@@ -221,8 +227,15 @@ fn run_explorer_loop(terminal: &mut Term, explorer: &mut Explorer) -> Result<()>
                 Action::Exit => return Ok(()),
                 Action::OpenFile(path) => {
                     if let Err(e) = tui::edit_file_in_terminal(terminal, &path) {
-                        explorer.status = Some(e.to_string());
+                        explorer.status = Some((e.to_string(), theme::ERROR));
                     }
+                }
+                Action::CopyPath(path) => {
+                    let shown = path.display().to_string();
+                    explorer.status = Some(match tui::copy_to_clipboard(&shown) {
+                        Ok(()) => (format!("copied {shown}"), theme::SUCCESS),
+                        Err(e) => (e.to_string(), theme::ERROR),
+                    });
                 }
             },
             Event::Tick => {}
@@ -254,7 +267,7 @@ fn handle_key(key: KeyEvent, explorer: &mut Explorer) -> Result<Action> {
                 .unwrap_or(false);
             if expandable {
                 if let Err(e) = explorer.expand(idx) {
-                    explorer.status = Some(e.to_string());
+                    explorer.status = Some((e.to_string(), theme::ERROR));
                 }
             }
         }
@@ -282,11 +295,19 @@ fn handle_key(key: KeyEvent, explorer: &mut Explorer) -> Result<Action> {
                     if expanded {
                         explorer.collapse(idx);
                     } else if let Err(e) = explorer.expand(idx) {
-                        explorer.status = Some(e.to_string());
+                        explorer.status = Some((e.to_string(), theme::ERROR));
                     }
                 } else {
                     return Ok(Action::OpenFile(path));
                 }
+            }
+        }
+
+        // Copy the selected entry's absolute path to the clipboard. Works on a
+        // file or a directory — either is a valid thing to hand an agent.
+        KeyCode::Char('y') => {
+            if let Some(node) = explorer.selected_node() {
+                return Ok(Action::CopyPath(node.entry.path.clone()));
             }
         }
 
@@ -338,8 +359,8 @@ fn render(frame: &mut Frame, explorer: &Explorer) {
     render_tree_pane(frame, panes[0], explorer);
     render_preview_pane(frame, panes[1], explorer);
 
-    if let Some(ref msg) = explorer.status {
-        frame.render_widget(Paragraph::new(msg.as_str()).style(theme::ERROR), chunks[1]);
+    if let Some((ref msg, style)) = explorer.status {
+        frame.render_widget(Paragraph::new(msg.as_str()).style(style), chunks[1]);
     }
     render_legend(frame, chunks[2]);
 }
@@ -406,6 +427,7 @@ fn render_legend(frame: &mut Frame, area: Rect) {
         ("→", " expand  "),
         ("←", " collapse/up  "),
         ("Enter/o", " open  "),
+        ("y", " copy path  "),
         ("g", " top  "),
         ("q", " quit"),
     ];
@@ -529,6 +551,27 @@ mod tests {
     /// Absolute path of `rel` under the explorer root, for asserting OpenFile.
     fn root_join(ex: &Explorer, rel: &str) -> PathBuf {
         ex.root.join(rel)
+    }
+
+    #[test]
+    fn y_asks_the_loop_to_copy_the_selected_path() {
+        let (_tmp, root) = temp_tree();
+        let mut ex = Explorer::new(root).unwrap();
+        ex.expand(1).unwrap(); // reveal note.md at idx 3
+        ex.selected = 3;
+
+        let action = handle_key(key(KeyCode::Char('y')), &mut ex).unwrap();
+        assert_eq!(action, Action::CopyPath(root_join(&ex, "proj/note.md")));
+    }
+
+    #[test]
+    fn y_copies_a_directory_path_too() {
+        let (_tmp, root) = temp_tree();
+        let mut ex = Explorer::new(root).unwrap();
+        ex.selected = 1; // proj/ (a directory)
+
+        let action = handle_key(key(KeyCode::Char('y')), &mut ex).unwrap();
+        assert_eq!(action, Action::CopyPath(root_join(&ex, "proj")));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -21,7 +21,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
-use std::io::{self, Stdout};
+use std::io::{self, Stdout, Write};
 use std::panic;
 use std::path::Path;
 use std::process::Command;
@@ -153,4 +153,74 @@ pub fn edit_file_in_terminal(terminal: &mut Term, path: &Path) -> Result<()> {
         message: format!("Failed to launch editor '{editor}': {e}"),
     })?;
     Ok(())
+}
+
+/// Copy `text` to the terminal's clipboard via the OSC 52 escape sequence.
+///
+/// OSC 52 is the one dependency-free way to reach the system clipboard: no
+/// `pbcopy`/`xclip`/`wl-copy` shell-out (a runtime dependency AKM does not
+/// take) and no clipboard crate. It rides the same stdout the TUI already
+/// owns and works over SSH.
+///
+/// The catch is that support is the terminal's to give: most modern emulators
+/// honour it (some need it enabled — e.g. tmux's `set-clipboard on`), and the
+/// rest silently drop the sequence. There is no reply to confirm receipt, so
+/// callers should also surface the copied text (the artifacts explorer prints
+/// it to the status line) as a mouse-selectable fallback.
+pub fn copy_to_clipboard(text: &str) -> Result<()> {
+    // ESC ] 52 ; c ; <base64> BEL — `c` selects the clipboard buffer.
+    let seq = format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
+    let mut stdout = io::stdout();
+    stdout.write_all(seq.as_bytes()).map_err(|e| Error::Tui {
+        message: format!("Failed to write to clipboard: {e}"),
+    })?;
+    stdout.flush().map_err(|e| Error::Tui {
+        message: format!("Failed to flush clipboard write: {e}"),
+    })?;
+    Ok(())
+}
+
+/// Standard base64 (RFC 4648) encoder, `=`-padded.
+///
+/// Hand-rolled to keep OSC 52 dependency-free — a full `base64` crate would be
+/// a runtime dependency for fifteen lines of table lookup.
+fn base64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(TABLE[(n >> 18 & 63) as usize] as char);
+        out.push(TABLE[(n >> 12 & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[(n >> 6 & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::base64_encode;
+
+    #[test]
+    fn base64_matches_known_vectors() {
+        // RFC 4648 §10 test vectors exercise every padding case.
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
 }


### PR DESCRIPTION
## What

Adds a `y` keybinding to the artifacts explorer that copies the selected entry's **absolute path** to the clipboard. Powers the flow: browsing artifacts, find the plan/doc you want, `y`, then paste it straight into an agent session.

Works on files and directories (either is a valid thing to hand an agent).

## How

- **OSC 52** escape sequence, not a clipboard crate or a `pbcopy`/`xclip`/`wl-copy` shell-out — keeps the single-binary / no-runtime-deps guarantee (review criterion #9) and works over SSH.
- base64 is hand-rolled (RFC 4648, `=`-padded) to avoid pulling in the `base64` crate for ~15 lines of table lookup.
- OSC 52 has no delivery ack and some terminals drop it, so the copied path is also printed to the status line as a mouse-selectable fallback (graceful degradation, criterion #10). Note: tmux needs `set-clipboard on`.
- `handle_key` stays pure — it returns `Action::CopyPath(path)` and the loop (which owns the terminal) does the write, mirroring the existing `OpenFile` seam. The status line gained a per-message style so a copy confirms in green (`copied <path>`) while errors stay red.

## Tests

- base64 against the RFC 4648 §10 vectors (every padding case)
- `y` on a file → `Action::CopyPath` with the file's path
- `y` on a directory → `Action::CopyPath` with the dir's path

`cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.

## Docs

README artifacts section documents the `y` key.

## Follow-up

A marks / `list-targets` feature is planned separately (mark multiple docs, copy-all, `akm artifacts marks` for cron/LLM worklists) — not in this PR.