### PR TITLE
feat(tui): gold theme, manifest-first status, `list` as default skills view

### DIFF
--- a/src/commands/skills/status.rs
+++ b/src/commands/skills/status.rs
@@ -52,40 +52,9 @@ fn run_plain(paths: &Paths, tool_dirs: &ToolDirs) -> Result<()> {
     }
     println!();
 
-    // Section 2: Core specs
-    println!("Core specs (globally symlinked):");
-    let core_specs = library.core_specs();
-    let core_ids: HashSet<&str> = core_specs.iter().map(|s| s.id.as_str()).collect();
-
-    for spec in &core_specs {
-        let type_label = format!("{:<6}", spec.spec_type);
-        let marker = drift.state_of(&spec.id).marker();
-        println!("  ✓ {type_label}  {marker} {}", spec.id);
-    }
-    println!();
-
-    // Section 3: Session specs (if AKM_SESSION is active)
-    let session_dir = env::var("AKM_SESSION").ok().map(PathBuf::from);
-    if let Some(ref staging) = session_dir {
-        if staging.is_dir() {
-            println!("Session specs (staging dir):");
-            let session_specs = scan_session_dir(staging, tool_dirs);
-            if session_specs.is_empty() {
-                println!("  (none loaded)");
-            } else {
-                for (id, spec_type) in &session_specs {
-                    let type_label = format!("{:<6}", spec_type);
-                    let marker = drift.state_of(id).marker();
-                    println!("  ✓ {type_label}  {marker} {id}");
-                }
-            }
-            println!();
-        }
-    }
-
-    // Section 4: Manifest specs
+    // Section 2: Manifest specs — this project's declared specs, shown first
+    // as the most relevant to the project the user is standing in.
     let mut manifest_ids: HashSet<String> = HashSet::new();
-
     if let Some(ref root) = project_root {
         let manifest_path = Manifest::path(root);
         if manifest_path.exists() {
@@ -122,6 +91,37 @@ fn run_plain(paths: &Paths, tool_dirs: &ToolDirs) -> Result<()> {
                 }
                 println!();
             }
+        }
+    }
+
+    // Section 3: Core specs
+    println!("Core specs (globally symlinked):");
+    let core_specs = library.core_specs();
+    let core_ids: HashSet<&str> = core_specs.iter().map(|s| s.id.as_str()).collect();
+
+    for spec in &core_specs {
+        let type_label = format!("{:<6}", spec.spec_type);
+        let marker = drift.state_of(&spec.id).marker();
+        println!("  ✓ {type_label}  {marker} {}", spec.id);
+    }
+    println!();
+
+    // Section 4: Session specs (if AKM_SESSION is active)
+    let session_dir = env::var("AKM_SESSION").ok().map(PathBuf::from);
+    if let Some(ref staging) = session_dir {
+        if staging.is_dir() {
+            println!("Session specs (staging dir):");
+            let session_specs = scan_session_dir(staging, tool_dirs);
+            if session_specs.is_empty() {
+                println!("  (none loaded)");
+            } else {
+                for (id, spec_type) in &session_specs {
+                    let type_label = format!("{:<6}", spec_type);
+                    let marker = drift.state_of(id).marker();
+                    println!("  ✓ {type_label}  {marker} {id}");
+                }
+            }
+            println!();
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ enum Commands {
     /// process embeds the old template, so it cannot refresh the script itself.
     #[command(hide = true, name = "shell-install")]
     ShellInstall,
-    /// Skills management (defaults to `status` when no subcommand is given)
+    /// Skills management (defaults to `list` when no subcommand is given)
     Skills {
         #[command(subcommand)]
         command: Option<SkillsCommands>,
@@ -575,8 +575,10 @@ fn main() -> ExitCode {
                     project_root,
                 }) => commands::skills::session_setup::run(&paths, &staging_dir, &project_root),
                 None => {
-                    // Default: `akm skills` with no subcommand → show status
-                    commands::skills::status::run(&paths, &tool_dirs, false)
+                    // Default: `akm skills` with no subcommand → browse the
+                    // library. The bare noun reads as `akm skills list`; the
+                    // richer status dashboard is an explicit `akm skills status`.
+                    commands::skills::list::run(&paths, None, None, false, &tool_dirs)
                 }
             }
         }

--- a/src/tui/status.rs
+++ b/src/tui/status.rs
@@ -1,6 +1,6 @@
 //! Status dashboard — interactive version of `akm skills status`.
 //!
-//! Displays the same sections as the plain output (core, session, manifest,
+//! Displays the same sections as the plain output (manifest, core, session,
 //! cold) but in a scrollable TUI with navigation and actions.
 //!
 //! Key bindings match the list view's normal mode, minus `/` — the dashboard
@@ -99,58 +99,8 @@ impl StatusView {
         }
         rows.push(StatusRow::Blank);
 
-        // Section 2: Core specs
-        rows.push(StatusRow::Header(
-            "Core specs (globally symlinked):".to_string(),
-        ));
-        let core_specs = app.library.core_specs();
-        let core_ids: HashSet<&str> = core_specs.iter().map(|s| s.id.as_str()).collect();
-        if core_specs.is_empty() {
-            rows.push(StatusRow::Empty("  (none)".to_string()));
-        } else {
-            for spec in &core_specs {
-                let idx = rows.len();
-                selectable_indices.push(idx);
-                rows.push(StatusRow::Spec {
-                    id: spec.id.clone(),
-                    spec_type: spec.spec_type,
-                    section: StatusSection::Core,
-                    note: None,
-                    drift: app.drift.state_of(&spec.id),
-                });
-            }
-        }
-        rows.push(StatusRow::Blank);
-
-        // Section 3: Session specs (if AKM_SESSION active)
-        let session_dir = env::var("AKM_SESSION").ok().map(PathBuf::from);
-        if let Some(ref staging) = session_dir {
-            if staging.is_dir() {
-                rows.push(StatusRow::Header(
-                    "Session specs (staging dir):".to_string(),
-                ));
-                let session_specs =
-                    crate::commands::skills::status::scan_session_dir(staging, &app.tool_dirs);
-                if session_specs.is_empty() {
-                    rows.push(StatusRow::Empty("  (none loaded)".to_string()));
-                } else {
-                    for (id, spec_type) in &session_specs {
-                        let idx = rows.len();
-                        selectable_indices.push(idx);
-                        rows.push(StatusRow::Spec {
-                            id: id.clone(),
-                            spec_type: *spec_type,
-                            section: StatusSection::Session,
-                            note: None,
-                            drift: app.drift.state_of(id),
-                        });
-                    }
-                }
-                rows.push(StatusRow::Blank);
-            }
-        }
-
-        // Section 4: Manifest specs
+        // Section 2: Manifest specs — this project's declared specs, shown
+        // first as the most relevant to the project the user is standing in.
         if app.project_root.is_some() {
             if let Some(manifest) = &app.manifest {
                 rows.push(StatusRow::Header(
@@ -195,6 +145,57 @@ impl StatusView {
 
                 if !has_entries {
                     rows.push(StatusRow::Empty("  (empty manifest)".to_string()));
+                }
+                rows.push(StatusRow::Blank);
+            }
+        }
+
+        // Section 3: Core specs
+        rows.push(StatusRow::Header(
+            "Core specs (globally symlinked):".to_string(),
+        ));
+        let core_specs = app.library.core_specs();
+        let core_ids: HashSet<&str> = core_specs.iter().map(|s| s.id.as_str()).collect();
+        if core_specs.is_empty() {
+            rows.push(StatusRow::Empty("  (none)".to_string()));
+        } else {
+            for spec in &core_specs {
+                let idx = rows.len();
+                selectable_indices.push(idx);
+                rows.push(StatusRow::Spec {
+                    id: spec.id.clone(),
+                    spec_type: spec.spec_type,
+                    section: StatusSection::Core,
+                    note: None,
+                    drift: app.drift.state_of(&spec.id),
+                });
+            }
+        }
+        rows.push(StatusRow::Blank);
+
+        // Section 4: Session specs (if AKM_SESSION active)
+        let session_dir = env::var("AKM_SESSION").ok().map(PathBuf::from);
+        if let Some(ref staging) = session_dir {
+            if staging.is_dir() {
+                rows.push(StatusRow::Header(
+                    "Session specs (staging dir):".to_string(),
+                ));
+                let session_specs =
+                    crate::commands::skills::status::scan_session_dir(staging, &app.tool_dirs);
+                if session_specs.is_empty() {
+                    rows.push(StatusRow::Empty("  (none loaded)".to_string()));
+                } else {
+                    for (id, spec_type) in &session_specs {
+                        let idx = rows.len();
+                        selectable_indices.push(idx);
+                        rows.push(StatusRow::Spec {
+                            id: id.clone(),
+                            spec_type: *spec_type,
+                            section: StatusSection::Session,
+                            note: None,
+                            drift: app.drift.state_of(id),
+                        });
+                    }
                 }
                 rows.push(StatusRow::Blank);
             }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,30 +1,56 @@
 //! Color and style constants for the TUI.
 //!
-//! The ANSI colour scheme, as ratatui styles:
-//! - skill type → `Color::Cyan`
-//! - agent type → `Color::Blue`
-//! - checkmark, [CORE] → `Color::Green`
-//! - warnings, "?" → `Color::Yellow`
-//! - errors → `Color::Red`
-//! - section headers → `Modifier::BOLD`
-//! - dimmed text → `Modifier::DIM`
+//! A black-and-gold scheme matching raphaelsimon.fr. Gold (`#eec35e`) is an
+//! *accent*, kept sparse the way the site keeps it: it marks focus (the
+//! selection bar and edit cursor), identity (the skill type, the `[CORE]`
+//! badge) — the TUI's analogs of the site's links and logo. Section headers
+//! stay neutral-bold, as the site's headings are white, not gold. Skills and
+//! agents keep two distinguishable shades of the one family (gold vs a dimmed
+//! bronze). Semantic status colours (success/warning/error) are preserved as
+//! distinct signals, warmed to sit in the palette.
+//!
+//! Colours are truecolour (`Rgb`); a non-truecolour terminal degrades them to
+//! the nearest 256-colour approximation.
 
 use ratatui::style::{Color, Modifier, Style};
 
+// --- Brand palette ---------------------------------------------------------
+
+/// Primary brand accent — raphaelsimon.fr gold.
+const GOLD: Color = Color::Rgb(0xee, 0xc3, 0x5e);
+/// Dimmed gold — separates the second family member (agents) from skills.
+const BRONZE: Color = Color::Rgb(0xb0, 0x85, 0x4a);
+/// Near-black foreground for text sitting on a gold fill.
+const INK: Color = Color::Rgb(0x1a, 0x17, 0x12);
+/// Warm charcoal fill for the search bar.
+const CHARCOAL: Color = Color::Rgb(0x2a, 0x26, 0x20);
+/// Warm grey for dimmed / help text (replaces cold DarkGray).
+const TAUPE: Color = Color::Rgb(0x8a, 0x81, 0x72);
+/// Warm parchment for text on a dark fill.
+const PARCHMENT: Color = Color::Rgb(0xed, 0xe6, 0xd6);
+/// Semantic success — muted olive.
+const OLIVE: Color = Color::Rgb(0x7a, 0x9a, 0x3e);
+/// Semantic warning — amber.
+const AMBER: Color = Color::Rgb(0xe8, 0x91, 0x2a);
+/// Semantic error — warm red.
+const WARM_RED: Color = Color::Rgb(0xd2, 0x41, 0x2e);
+
+// --- Semantic styles -------------------------------------------------------
+
 /// Style for skill type labels.
-pub const SKILL_TYPE: Style = Style::new().fg(Color::Cyan);
+pub const SKILL_TYPE: Style = Style::new().fg(GOLD);
 
 /// Style for agent type labels.
-pub const AGENT_TYPE: Style = Style::new().fg(Color::Blue);
+pub const AGENT_TYPE: Style = Style::new().fg(BRONZE);
 
 /// Style for success indicators (✓, [CORE]).
-pub const SUCCESS: Style = Style::new().fg(Color::Green);
+pub const SUCCESS: Style = Style::new().fg(OLIVE);
 
 /// Style for warnings (?).
-pub const WARNING: Style = Style::new().fg(Color::Yellow);
+pub const WARNING: Style = Style::new().fg(AMBER);
 
 /// Style for errors and states that need a decision.
-pub const ERROR: Style = Style::new().fg(Color::Red);
+pub const ERROR: Style = Style::new().fg(WARM_RED);
 
 /// Style for section headers.
 pub const HEADER: Style = Style::new().add_modifier(Modifier::BOLD);
@@ -32,29 +58,27 @@ pub const HEADER: Style = Style::new().add_modifier(Modifier::BOLD);
 /// Style for dimmed text.
 pub const DIM: Style = Style::new().add_modifier(Modifier::DIM);
 
-/// Style for the selected row in a list.
-pub const SELECTED: Style = Style::new()
-    .fg(Color::Black)
-    .bg(Color::Cyan)
-    .add_modifier(Modifier::BOLD);
+/// Style for the selected row in a list — the signature gold bar.
+pub const SELECTED: Style = Style::new().fg(INK).bg(GOLD).add_modifier(Modifier::BOLD);
 
 /// Style for the text cell the edit cursor sits on.
 ///
 /// Reversed rather than a block glyph, so it reads correctly wherever it lands
-/// in a wrapped field — including past the last character.
-pub const CURSOR: Style = Style::new().fg(Color::Black).bg(Color::Cyan);
+/// in a wrapped field — including past the last character. Shares the selection
+/// bar's gold so focus reads the same everywhere.
+pub const CURSOR: Style = Style::new().fg(INK).bg(GOLD);
 
 /// Style for the contents of a text field that does not have focus.
 pub const FIELD_BLURRED: Style = Style::new().add_modifier(Modifier::DIM);
 
 /// Style for the search/filter bar.
-pub const SEARCH_BAR: Style = Style::new().fg(Color::White).bg(Color::DarkGray);
+pub const SEARCH_BAR: Style = Style::new().fg(PARCHMENT).bg(CHARCOAL);
 
 /// Style for the help bar at the bottom.
-pub const HELP_BAR: Style = Style::new().fg(Color::DarkGray);
+pub const HELP_BAR: Style = Style::new().fg(TAUPE);
 
 /// Style for the core flag indicator in rows.
-pub const CORE_BADGE: Style = Style::new().fg(Color::Green).add_modifier(Modifier::BOLD);
+pub const CORE_BADGE: Style = Style::new().fg(GOLD).add_modifier(Modifier::BOLD);
 
 /// Return the style for a drift marker.
 ///

--- a/tests/snapshots/help_test__help_output.snap
+++ b/tests/snapshots/help_test__help_output.snap
@@ -11,7 +11,7 @@ Commands:
   config        View, get, or set configuration values
   sync          Sync all enabled features (skills, artifacts, instructions)
   update        Check for a new release and self-update the akm binary
-  skills        Skills management (defaults to `status` when no subcommand is given)
+  skills        Skills management (defaults to `list` when no subcommand is given)
   artifacts     Browse artifacts, or sync (defaults to the explorer with no subcommand)
   instructions  Global instruction management
   completions   Generate shell completion script

--- a/tests/snapshots/help_test__skills_help_output.snap
+++ b/tests/snapshots/help_test__skills_help_output.snap
@@ -2,7 +2,7 @@
 source: tests/help_test.rs
 expression: "String::from_utf8_lossy(&output.stdout).to_string()"
 ---
-Skills management (defaults to `status` when no subcommand is given)
+Skills management (defaults to `list` when no subcommand is given)
 
 Usage: akm skills [COMMAND]
 


### PR DESCRIPTION
Three small UX/UI changes.

## 1. Black-and-gold theme
Rebrands the TUI palette from blue accents to the black-and-gold of [raphaelsimon.fr](https://raphaelsimon.fr) (`#eec35e`), applied entirely through `theme.rs` so all four TUIs (skills list, skills status, artifacts, config) recolor consistently.

Gold is kept an **accent**, matching how the site uses it (links/identity only, never a fill):
- selection bar + edit cursor → gold on warm-black (the signature focus cue)
- skill type + `[CORE]` badge → gold
- agent type → dimmed **bronze** (same hue family, keeps skill/agent distinct — replaces the old cyan-vs-blue pair)
- help/dim text → warm taupe (was cold DarkGray); search bar → parchment on warm charcoal
- success / warning / error → kept as distinct signals, warmed to olive / amber / warm-red (recoloring `error` to gold would destroy the red=danger signal)
- section headers stay neutral-bold — the site's headings are white, not gold

Truecolour `Rgb`; degrades to nearest-256 on non-truecolour terminals.

## 2. Manifest-first in `skills status`
The status view now lists the **Manifest** section first, above Core, in both the TUI dashboard and `--plain` output. When you're standing in a project, its declared specs are the most relevant thing to see. New section order: Project → Manifest → Core → Session → Cold.

## 3. `akm skills` defaults to `list`
Bare `akm skills` now opens the library list instead of the status dashboard. The bare noun reads as `akm skills list` (least surprise, matches the subcommand name and the "browse your library" mental model); the richer diagnostic dashboard stays an explicit `akm skills status`. Pre-1.0, no scripts depend on the old default.

## Tests
Reordering is presence-checked by existing plain-output tests (unaffected). The default-command change updates the two `--help` snapshots (`status` → `list`, verified as the only diff). `cargo test`, `clippy -D warnings`, `fmt --check` all clean.