### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 1.0.0
+
+First stable release.
+
+- Artifacts explorer: press `y` to copy the selected entry's absolute path to
+  the clipboard, for pasting straight into an agent. Uses OSC 52 (no clipboard
+  crate, no `pbcopy`/`xclip`/`wl-copy` shell-out), so it keeps the
+  single-binary guarantee and works over SSH. The path is also shown in the
+  status line as a selectable fallback for terminals that drop OSC 52.
+- TUI theme: rebranded from blue accents to black-and-gold (`#eec35e`) — gold
+  marks the selection bar, edit cursor, skill type and the `[CORE]` badge, with
+  the semantic status colours kept as distinct signals.
+- `akm skills status` now shows the Manifest section first, above Core, in both
+  the TUI dashboard and `--plain` output — a project's declared specs are the
+  most relevant thing to see when standing in it.
+- Bare `akm skills` now opens the library list (like `akm skills list`) instead
+  of the status dashboard; the dashboard stays an explicit `akm skills status`.
+
 # 1.0.0-rc6
 
 - Add `akm uninstall` — removes the binary, ~/.bashrc integration block,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "akm"
-version = "1.0.0-rc6"
+version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akm"
-version = "1.0.0-rc6"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Agent Kit Manager — manage reusable LLM skills, artifacts, and instructions"

--- a/tests/snapshots/update_test__version_output.snap
+++ b/tests/snapshots/update_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/update_test.rs
 expression: stdout.trim()
 ---
-akm 1.0.0-rc6
+akm 1.0.0


### PR DESCRIPTION
First stable release of akm.

## Release checklist
- [x] Bump `version` in `Cargo.toml` (1.0.0-rc6 → 1.0.0) + `Cargo.lock`
- [x] `tests/snapshots/update_test__version_output.snap` → `akm 1.0.0`
- [x] `CHANGELOG.md`: cut the `# 1.0.0` heading for the features landed since rc6 (#53, #54)
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass

## Ships since rc6
- Artifacts explorer `y` → copy selected path via OSC 52 (#53)
- Gold TUI theme, manifest-first `skills status`, bare `akm skills` → list (#54)

After merge, tag `v1.0.0` on main and push to trigger the release workflow (GitHub release + crates.io publish). `akm update` resolves via `/releases/latest`; 1.0.0 ships as a normal (non-prerelease) release, so it becomes GitHub's Latest and `is_newer("1.0.0-rc6", "1.0.0")` is true — rc6 users get the upgrade notice.